### PR TITLE
Remove EvaluationOptions from  method signatures

### DIFF
--- a/open_feature/open_feature_client.py
+++ b/open_feature/open_feature_client.py
@@ -43,12 +43,14 @@ class OpenFeatureClient:
         key: str,
         default_value: bool,
         evaluation_context: EvaluationContext = None,
+        flag_evaluation_options: typing.Any = None,
     ) -> bool:
         return self.evaluate_flag_details(
             FlagType.BOOLEAN,
             key,
             default_value,
             evaluation_context,
+            flag_evaluation_options,
         ).value
 
     def get_boolean_details(
@@ -56,12 +58,14 @@ class OpenFeatureClient:
         key: str,
         default_value: bool,
         evaluation_context: EvaluationContext = None,
+        flag_evaluation_options: typing.Any = None,
     ) -> FlagEvaluationDetails:
         return self.evaluate_flag_details(
             FlagType.BOOLEAN,
             key,
             default_value,
             evaluation_context,
+            flag_evaluation_options,
         )
 
     def get_string_value(
@@ -69,12 +73,14 @@ class OpenFeatureClient:
         key: str,
         default_value: str,
         evaluation_context: EvaluationContext = None,
+        flag_evaluation_options: typing.Any = None,
     ) -> str:
         return self.evaluate_flag_details(
             FlagType.STRING,
             key,
             default_value,
             evaluation_context,
+            flag_evaluation_options,
         ).value
 
     def get_string_details(
@@ -82,12 +88,14 @@ class OpenFeatureClient:
         key: str,
         default_value: str,
         evaluation_context: EvaluationContext = None,
+        flag_evaluation_options: typing.Any = None,
     ) -> FlagEvaluationDetails:
         return self.evaluate_flag_details(
             FlagType.STRING,
             key,
             default_value,
             evaluation_context,
+            flag_evaluation_options,
         )
 
     def get_number_value(
@@ -95,12 +103,14 @@ class OpenFeatureClient:
         key: str,
         default_value: Number,
         evaluation_context: EvaluationContext = None,
+        flag_evaluation_options: typing.Any = None,
     ) -> Number:
         return self.evaluate_flag_details(
             FlagType.NUMBER,
             key,
             default_value,
             evaluation_context,
+            flag_evaluation_options,
         ).value
 
     def get_number_details(
@@ -108,12 +118,14 @@ class OpenFeatureClient:
         key: str,
         default_value: Number,
         evaluation_context: EvaluationContext = None,
+        flag_evaluation_options: typing.Any = None,
     ) -> FlagEvaluationDetails:
         return self.evaluate_flag_details(
             FlagType.NUMBER,
             key,
             default_value,
             evaluation_context,
+            flag_evaluation_options,
         )
 
     def get_object_value(
@@ -121,12 +133,14 @@ class OpenFeatureClient:
         key: str,
         default_value: dict,
         evaluation_context: EvaluationContext = None,
+        flag_evaluation_options: typing.Any = None,
     ) -> dict:
         return self.evaluate_flag_details(
             FlagType.OBJECT,
             key,
             default_value,
             evaluation_context,
+            flag_evaluation_options,
         ).value
 
     def get_object_details(
@@ -134,12 +148,14 @@ class OpenFeatureClient:
         key: str,
         default_value: dict,
         evaluation_context: EvaluationContext = None,
+        flag_evaluation_options: typing.Any = None,
     ) -> FlagEvaluationDetails:
         return self.evaluate_flag_details(
             FlagType.OBJECT,
             key,
             default_value,
             evaluation_context,
+            flag_evaluation_options,
         )
 
     def evaluate_flag_details(
@@ -148,6 +164,7 @@ class OpenFeatureClient:
         key: str,
         default_value: typing.Any,
         evaluation_context: EvaluationContext = None,
+        flag_evaluation_options: typing.Any = None,
     ) -> FlagEvaluationDetails:
         """
         Evaluate the flag requested by the user from the clients provider.

--- a/open_feature/open_feature_client.py
+++ b/open_feature/open_feature_client.py
@@ -244,7 +244,6 @@ class OpenFeatureClient:
         :param key: the string key of the selected flag
         :param default_value: backup value returned if no result found by the provider
         :param evaluation_context: Information for the purposes of flag evaluation
-        :param flag_evaluation_options: Additional flag evaluation information
         :return: a FlagEvaluationDetails object with the fully evaluated flag from a
         provider
         """

--- a/open_feature/open_feature_client.py
+++ b/open_feature/open_feature_client.py
@@ -43,14 +43,12 @@ class OpenFeatureClient:
         key: str,
         default_value: bool,
         evaluation_context: EvaluationContext = None,
-        flag_evaluation_options: typing.Any = None,
     ) -> bool:
         return self.evaluate_flag_details(
             FlagType.BOOLEAN,
             key,
             default_value,
             evaluation_context,
-            flag_evaluation_options,
         ).value
 
     def get_boolean_details(
@@ -58,14 +56,12 @@ class OpenFeatureClient:
         key: str,
         default_value: bool,
         evaluation_context: EvaluationContext = None,
-        flag_evaluation_options: typing.Any = None,
     ) -> FlagEvaluationDetails:
         return self.evaluate_flag_details(
             FlagType.BOOLEAN,
             key,
             default_value,
             evaluation_context,
-            flag_evaluation_options,
         )
 
     def get_string_value(
@@ -73,14 +69,12 @@ class OpenFeatureClient:
         key: str,
         default_value: str,
         evaluation_context: EvaluationContext = None,
-        flag_evaluation_options: typing.Any = None,
     ) -> str:
         return self.evaluate_flag_details(
             FlagType.STRING,
             key,
             default_value,
             evaluation_context,
-            flag_evaluation_options,
         ).value
 
     def get_string_details(
@@ -88,14 +82,12 @@ class OpenFeatureClient:
         key: str,
         default_value: str,
         evaluation_context: EvaluationContext = None,
-        flag_evaluation_options: typing.Any = None,
     ) -> FlagEvaluationDetails:
         return self.evaluate_flag_details(
             FlagType.STRING,
             key,
             default_value,
             evaluation_context,
-            flag_evaluation_options,
         )
 
     def get_number_value(
@@ -103,14 +95,12 @@ class OpenFeatureClient:
         key: str,
         default_value: Number,
         evaluation_context: EvaluationContext = None,
-        flag_evaluation_options: typing.Any = None,
     ) -> Number:
         return self.evaluate_flag_details(
             FlagType.NUMBER,
             key,
             default_value,
             evaluation_context,
-            flag_evaluation_options,
         ).value
 
     def get_number_details(
@@ -118,14 +108,12 @@ class OpenFeatureClient:
         key: str,
         default_value: Number,
         evaluation_context: EvaluationContext = None,
-        flag_evaluation_options: typing.Any = None,
     ) -> FlagEvaluationDetails:
         return self.evaluate_flag_details(
             FlagType.NUMBER,
             key,
             default_value,
             evaluation_context,
-            flag_evaluation_options,
         )
 
     def get_object_value(
@@ -133,14 +121,12 @@ class OpenFeatureClient:
         key: str,
         default_value: dict,
         evaluation_context: EvaluationContext = None,
-        flag_evaluation_options: typing.Any = None,
     ) -> dict:
         return self.evaluate_flag_details(
             FlagType.OBJECT,
             key,
             default_value,
             evaluation_context,
-            flag_evaluation_options,
         ).value
 
     def get_object_details(
@@ -148,14 +134,12 @@ class OpenFeatureClient:
         key: str,
         default_value: dict,
         evaluation_context: EvaluationContext = None,
-        flag_evaluation_options: typing.Any = None,
     ) -> FlagEvaluationDetails:
         return self.evaluate_flag_details(
             FlagType.OBJECT,
             key,
             default_value,
             evaluation_context,
-            flag_evaluation_options,
         )
 
     def evaluate_flag_details(
@@ -164,7 +148,6 @@ class OpenFeatureClient:
         key: str,
         default_value: typing.Any,
         evaluation_context: EvaluationContext = None,
-        flag_evaluation_options: typing.Any = None,
     ) -> FlagEvaluationDetails:
         """
         Evaluate the flag requested by the user from the clients provider.
@@ -210,7 +193,6 @@ class OpenFeatureClient:
                 key,
                 default_value,
                 merged_context,
-                flag_evaluation_options,
             )
 
             after_hooks(type, hook_context, flag_evaluation, merged_hooks, None)
@@ -237,7 +219,6 @@ class OpenFeatureClient:
         key: str,
         default_value: typing.Any,
         evaluation_context: EvaluationContext = None,
-        flag_evaluation_options: typing.Any = None,
     ) -> FlagEvaluationDetails:
         """
         Encapsulated method to create a FlagEvaluationDetail from a specific provider.
@@ -254,7 +235,6 @@ class OpenFeatureClient:
             key,
             default_value,
             evaluation_context,
-            flag_evaluation_options,
         )
 
         if not self.provider:

--- a/open_feature/provider/no_op_provider.py
+++ b/open_feature/provider/no_op_provider.py
@@ -1,4 +1,3 @@
-import typing
 from numbers import Number
 
 from open_feature.evaluation_context.evaluation_context import EvaluationContext
@@ -18,7 +17,6 @@ class NoOpProvider(AbstractProvider):
         key: str,
         default_value: bool,
         evaluation_context: EvaluationContext = None,
-        flag_evaluation_options: typing.Any = None,
     ):
         return FlagEvaluationDetails(
             key=key,
@@ -32,7 +30,6 @@ class NoOpProvider(AbstractProvider):
         key: str,
         default_value: str,
         evaluation_context: EvaluationContext = None,
-        flag_evaluation_options: typing.Any = None,
     ):
         return FlagEvaluationDetails(
             key=key,
@@ -46,7 +43,6 @@ class NoOpProvider(AbstractProvider):
         key: str,
         default_value: Number,
         evaluation_context: EvaluationContext = None,
-        flag_evaluation_options: typing.Any = None,
     ):
         return FlagEvaluationDetails(
             key=key,
@@ -60,7 +56,6 @@ class NoOpProvider(AbstractProvider):
         key: str,
         default_value: dict,
         evaluation_context: EvaluationContext = None,
-        flag_evaluation_options: typing.Any = None,
     ):
         return FlagEvaluationDetails(
             key=key,

--- a/open_feature/provider/provider.py
+++ b/open_feature/provider/provider.py
@@ -1,4 +1,3 @@
-import typing
 from abc import abstractmethod
 from numbers import Number
 
@@ -16,7 +15,6 @@ class AbstractProvider:
         key: str,
         default_value: bool,
         evaluation_context: EvaluationContext = EvaluationContext(),
-        flag_evaluation_options: typing.Any = None,
     ):
         pass
 
@@ -26,7 +24,6 @@ class AbstractProvider:
         key: str,
         default_value: str,
         evaluation_context: EvaluationContext = EvaluationContext(),
-        flag_evaluation_options: typing.Any = None,
     ):
         pass
 
@@ -36,7 +33,6 @@ class AbstractProvider:
         key: str,
         default_value: Number,
         evaluation_context: EvaluationContext = EvaluationContext(),
-        flag_evaluation_options: typing.Any = None,
     ):
         pass
 
@@ -46,6 +42,5 @@ class AbstractProvider:
         key: str,
         default_value: dict,
         evaluation_context: EvaluationContext = EvaluationContext(),
-        flag_evaluation_options: typing.Any = None,
     ):
         pass


### PR DESCRIPTION
This PR removes `EvaluationOptions` from all method signatures in the provider's interface as per the breaking changes of v0.4.0 of the OpenFeature spec.
This fixes #10! 

Signed-off-by: Manuel Schönlaub <manuel.schoenlaub@gmail.com>