### PR TITLE
fix license to allow pypi upload

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 authors = [{ name = "Open Feature", email = "opensource@dynatrace.com" }]
 license = { file = "LICENSE" }
 classifiers = [
-    "License :: OSI Approved :: Apache",
+    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
 ]


### PR DESCRIPTION
Signed-off-by: agardnerit <adam@agardner.net>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
 - Updates the classifier to a valid Python classifier
 - This update means pypi uploads won't fail due to an invalid classifier error

## How to test

```
python3 -m twine upload --repository testpypi dist/*
```
Before the changes gives this:
```
Uploading python_open_feature_sdk-0.0.1-py3-none-any.whl
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 33.9/33.9 kB • 00:00 • 20.2 MB/s
WARNING  Error during upload. Retry with the --verbose option for more details.                   
ERROR    HTTPError: 400 Bad Request from https://test.pypi.org/legacy/                            
         Invalid value for classifiers. Error: Classifier 'License :: OSI Approved :: Apache' is  
         not a valid classifier.
```

After this PR:
```
Uploading python_open_feature_sdk-0.0.1-py3-none-any.whl
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 33.9/33.9 kB • 00:00 • 20.8 MB/s
Uploading python_open_feature_sdk-0.0.1.tar.gz
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 33.4/33.4 kB • 00:00 • 19.5 MB/s

View at:
https://test.pypi.org/project/python-open-feature-sdk/0.0.1/
```