### PR TITLE
fix: Fix type checking

### DIFF
--- a/open_feature/evaluation_context/evaluation_context.py
+++ b/open_feature/evaluation_context/evaluation_context.py
@@ -1,5 +1,12 @@
+import typing
+
+
 class EvaluationContext:
-    def __init__(self, targeting_key: str = None, attributes: dict = None):
+    def __init__(
+        self,
+        targeting_key: typing.Optional[str] = None,
+        attributes: typing.Optional[dict] = None,
+    ):
         self.targeting_key = targeting_key
         self.attributes = attributes or {}
 

--- a/open_feature/exception/exceptions.py
+++ b/open_feature/exception/exceptions.py
@@ -10,7 +10,7 @@ class OpenFeatureError(Exception):
     """
 
     def __init__(
-        self, error_message: typing.Optional[str] = None, error_code: ErrorCode = None
+        self, error_code: ErrorCode, error_message: typing.Optional[str] = None
     ):
         """
         Constructor for the generic OpenFeatureError.
@@ -35,7 +35,7 @@ class FlagNotFoundError(OpenFeatureError):
         @param error_message: an optional string message representing
         why the error has been raised
         """
-        super().__init__(error_message, ErrorCode.FLAG_NOT_FOUND)
+        super().__init__(ErrorCode.FLAG_NOT_FOUND, error_message)
 
 
 class GeneralError(OpenFeatureError):
@@ -51,7 +51,7 @@ class GeneralError(OpenFeatureError):
         @param error_message: an optional string message representing why the error
         has been raised
         """
-        super().__init__(error_message, ErrorCode.GENERAL)
+        super().__init__(ErrorCode.GENERAL, error_message)
 
 
 class ParseError(OpenFeatureError):
@@ -67,7 +67,7 @@ class ParseError(OpenFeatureError):
         @param error_message: an optional string message representing why the
         error has been raised
         """
-        super().__init__(error_message, ErrorCode.PARSE_ERROR)
+        super().__init__(ErrorCode.PARSE_ERROR, error_message)
 
 
 class TypeMismatchError(OpenFeatureError):
@@ -83,7 +83,7 @@ class TypeMismatchError(OpenFeatureError):
         @param error_message: an optional string message representing why the
         error has been raised
         """
-        super().__init__(error_message, ErrorCode.TYPE_MISMATCH)
+        super().__init__(ErrorCode.TYPE_MISMATCH, error_message)
 
 
 class TargetingKeyMissingError(OpenFeatureError):
@@ -92,14 +92,14 @@ class TargetingKeyMissingError(OpenFeatureError):
     but one was not provided in the evaluation context.
     """
 
-    def __init__(self, error_message: str = None):
+    def __init__(self, error_message: typing.Optional[str] = None):
         """
         Constructor for the TargetingKeyMissingError. The error code for this type of
         exception is ErrorCode.TARGETING_KEY_MISSING.
         @param error_message: a string message representing why the error has been
         raised
         """
-        super().__init__(error_message, ErrorCode.TARGETING_KEY_MISSING)
+        super().__init__(ErrorCode.TARGETING_KEY_MISSING, error_message)
 
 
 class InvalidContextError(OpenFeatureError):
@@ -108,11 +108,11 @@ class InvalidContextError(OpenFeatureError):
     requirements.
     """
 
-    def __init__(self, error_message: str = None):
+    def __init__(self, error_message: typing.Optional[str]):
         """
         Constructor for the InvalidContextError. The error code for this type of
         exception is ErrorCode.INVALID_CONTEXT.
         @param error_message: a string message representing why the error has been
         raised
         """
-        super().__init__(error_message, ErrorCode.INVALID_CONTEXT)
+        super().__init__(ErrorCode.INVALID_CONTEXT, error_message)

--- a/open_feature/flag_evaluation/flag_evaluation_details.py
+++ b/open_feature/flag_evaluation/flag_evaluation_details.py
@@ -9,7 +9,7 @@ from open_feature.flag_evaluation.reason import Reason
 class FlagEvaluationDetails:
     flag_key: str
     value: typing.Any
-    variant: str = None
-    reason: Reason = None
-    error_code: ErrorCode = None
+    variant: typing.Optional[str] = None
+    reason: typing.Optional[Reason] = None
+    error_code: typing.Optional[ErrorCode] = None
     error_message: typing.Optional[str] = None

--- a/open_feature/flag_evaluation/flag_evaluation_details.py
+++ b/open_feature/flag_evaluation/flag_evaluation_details.py
@@ -4,11 +4,13 @@ from dataclasses import dataclass
 from open_feature.exception.error_code import ErrorCode
 from open_feature.flag_evaluation.reason import Reason
 
+T = typing.TypeVar("T", covariant=True)
+
 
 @dataclass
-class FlagEvaluationDetails:
+class FlagEvaluationDetails(typing.Generic[T]):
     flag_key: str
-    value: typing.Any
+    value: T
     variant: typing.Optional[str] = None
     reason: typing.Optional[Reason] = None
     error_code: typing.Optional[ErrorCode] = None

--- a/open_feature/hooks/hook_context.py
+++ b/open_feature/hooks/hook_context.py
@@ -11,5 +11,5 @@ class HookContext:
     flag_type: FlagType
     default_value: typing.Any
     evaluation_context: EvaluationContext
-    client_metadata: dict = None
-    provider_metadata: dict = None
+    client_metadata: typing.Optional[dict] = None
+    provider_metadata: typing.Optional[dict] = None

--- a/open_feature/hooks/hook_support.py
+++ b/open_feature/hooks/hook_support.py
@@ -15,7 +15,7 @@ def error_hooks(
     hook_context: HookContext,
     exception: Exception,
     hooks: typing.List[Hook],
-    hints: dict,
+    hints: dict = None,
 ):
     kwargs = {"hook_context": hook_context, "exception": exception, "hints": hints}
     _execute_hooks(
@@ -27,7 +27,7 @@ def after_all_hooks(
     flag_type: FlagType,
     hook_context: HookContext,
     hooks: typing.List[Hook],
-    hints: dict,
+    hints: typing.Optional[typing.Mapping],
 ):
     kwargs = {"hook_context": hook_context, "hints": hints}
     _execute_hooks(
@@ -40,7 +40,7 @@ def after_hooks(
     hook_context: HookContext,
     details: FlagEvaluationDetails,
     hooks: typing.List[Hook],
-    hints: dict,
+    hints: typing.Optional[typing.Mapping],
 ):
     kwargs = {"hook_context": hook_context, "details": details, "hints": hints}
     _execute_hooks_unchecked(
@@ -52,7 +52,7 @@ def before_hooks(
     flag_type: FlagType,
     hook_context: HookContext,
     hooks: typing.List[Hook],
-    hints: dict,
+    hints: typing.Optional[dict],
 ) -> EvaluationContext:
     kwargs = {"hook_context": hook_context, "hints": hints}
     executed_hooks = _execute_hooks_unchecked(

--- a/open_feature/hooks/hook_support.py
+++ b/open_feature/hooks/hook_support.py
@@ -52,7 +52,7 @@ def before_hooks(
     flag_type: FlagType,
     hook_context: HookContext,
     hooks: typing.List[Hook],
-    hints: typing.Optional[dict],
+    hints: typing.Optional[typing.Mapping] = None,
 ) -> EvaluationContext:
     kwargs = {"hook_context": hook_context, "hints": hints}
     executed_hooks = _execute_hooks_unchecked(

--- a/open_feature/hooks/hook_support.py
+++ b/open_feature/hooks/hook_support.py
@@ -15,7 +15,7 @@ def error_hooks(
     hook_context: HookContext,
     exception: Exception,
     hooks: typing.List[Hook],
-    hints: dict = None,
+    hints: typing.Optional[typing.Mapping] = None,
 ):
     kwargs = {"hook_context": hook_context, "exception": exception, "hints": hints}
     _execute_hooks(
@@ -27,7 +27,7 @@ def after_all_hooks(
     flag_type: FlagType,
     hook_context: HookContext,
     hooks: typing.List[Hook],
-    hints: typing.Optional[typing.Mapping],
+    hints: typing.Optional[typing.Mapping] = None,
 ):
     kwargs = {"hook_context": hook_context, "hints": hints}
     _execute_hooks(
@@ -40,7 +40,7 @@ def after_hooks(
     hook_context: HookContext,
     details: FlagEvaluationDetails,
     hooks: typing.List[Hook],
-    hints: typing.Optional[typing.Mapping],
+    hints: typing.Optional[typing.Mapping] = None,
 ):
     kwargs = {"hook_context": hook_context, "details": details, "hints": hints}
     _execute_hooks_unchecked(

--- a/open_feature/open_feature_api.py
+++ b/open_feature/open_feature_api.py
@@ -4,10 +4,12 @@ from open_feature.exception.exceptions import GeneralError
 from open_feature.open_feature_client import OpenFeatureClient
 from open_feature.provider.provider import AbstractProvider
 
-_provider = None
+_provider: typing.Optional[AbstractProvider] = None
 
 
-def get_client(name: str = None, version: str = None) -> OpenFeatureClient:
+def get_client(
+    name: typing.Optional[str] = None, version: typing.Optional[str] = None
+) -> OpenFeatureClient:
     if _provider is None:
         raise GeneralError(
             error_message="Provider not set. Call set_provider before using get_client"

--- a/open_feature/open_feature_client.py
+++ b/open_feature/open_feature_client.py
@@ -8,8 +8,6 @@ from open_feature.exception.exceptions import (
     OpenFeatureError,
     TypeMismatchError,
 )
-from open_feature.exception.exceptions import GeneralError
-from open_feature.flag_evaluation.error_code import ErrorCode
 from open_feature.flag_evaluation.flag_evaluation_details import FlagEvaluationDetails
 from open_feature.flag_evaluation.flag_evaluation_options import FlagEvaluationOptions
 from open_feature.flag_evaluation.flag_type import FlagType
@@ -26,20 +24,34 @@ from open_feature.open_feature_evaluation_context import api_evaluation_context
 from open_feature.provider.no_op_provider import NoOpProvider
 from open_feature.provider.provider import AbstractProvider
 
-NUMERIC_TYPES = [FlagType.FLOAT, FlagType.INTEGER]
-GetDetailsCallable = typing.Callable[
-    [str, typing.Any, typing.Optional[EvaluationContext]], FlagEvaluationDetails
+
+GetDetailCallable = typing.Union[
+    typing.Callable[
+        [str, bool, typing.Optional[EvaluationContext]], FlagEvaluationDetails[bool]
+    ],
+    typing.Callable[
+        [str, int, typing.Optional[EvaluationContext]], FlagEvaluationDetails[int]
+    ],
+    typing.Callable[
+        [str, float, typing.Optional[EvaluationContext]], FlagEvaluationDetails[float]
+    ],
+    typing.Callable[
+        [str, str, typing.Optional[EvaluationContext]], FlagEvaluationDetails[str]
+    ],
+    typing.Callable[
+        [str, dict, typing.Optional[EvaluationContext]], FlagEvaluationDetails[dict]
+    ],
 ]
 
 
 class OpenFeatureClient:
     def __init__(
         self,
-        name: str,
-        version: str,
-        context: EvaluationContext = None,
-        hooks: typing.List[Hook] = None,
-        provider: AbstractProvider = None,
+        name: typing.Optional[str],
+        version: typing.Optional[str],
+        provider: AbstractProvider,
+        context: typing.Optional[EvaluationContext] = None,
+        hooks: typing.Optional[typing.List[Hook]] = None,
     ):
         self.name = name
         self.version = version
@@ -54,8 +66,8 @@ class OpenFeatureClient:
         self,
         flag_key: str,
         default_value: bool,
-        evaluation_context: EvaluationContext = None,
-        flag_evaluation_options: FlagEvaluationOptions = None,
+        evaluation_context: typing.Optional[EvaluationContext] = None,
+        flag_evaluation_options: typing.Optional[FlagEvaluationOptions] = None,
     ) -> bool:
         return self.evaluate_flag_details(
             FlagType.BOOLEAN,
@@ -69,8 +81,8 @@ class OpenFeatureClient:
         self,
         flag_key: str,
         default_value: bool,
-        evaluation_context: EvaluationContext = None,
-        flag_evaluation_options: FlagEvaluationOptions = None,
+        evaluation_context: typing.Optional[EvaluationContext] = None,
+        flag_evaluation_options: typing.Optional[FlagEvaluationOptions] = None,
     ) -> FlagEvaluationDetails:
         return self.evaluate_flag_details(
             FlagType.BOOLEAN,
@@ -84,8 +96,8 @@ class OpenFeatureClient:
         self,
         flag_key: str,
         default_value: str,
-        evaluation_context: EvaluationContext = None,
-        flag_evaluation_options: FlagEvaluationOptions = None,
+        evaluation_context: typing.Optional[EvaluationContext] = None,
+        flag_evaluation_options: typing.Optional[FlagEvaluationOptions] = None,
     ) -> str:
         return self.evaluate_flag_details(
             FlagType.STRING,
@@ -99,8 +111,8 @@ class OpenFeatureClient:
         self,
         flag_key: str,
         default_value: str,
-        evaluation_context: EvaluationContext = None,
-        flag_evaluation_options: FlagEvaluationOptions = None,
+        evaluation_context: typing.Optional[EvaluationContext] = None,
+        flag_evaluation_options: typing.Optional[FlagEvaluationOptions] = None,
     ) -> FlagEvaluationDetails:
         return self.evaluate_flag_details(
             FlagType.STRING,
@@ -114,8 +126,8 @@ class OpenFeatureClient:
         self,
         flag_key: str,
         default_value: int,
-        evaluation_context: EvaluationContext = None,
-        flag_evaluation_options: FlagEvaluationOptions = None,
+        evaluation_context: typing.Optional[EvaluationContext] = None,
+        flag_evaluation_options: typing.Optional[FlagEvaluationOptions] = None,
     ) -> int:
         return self.get_integer_details(
             flag_key,
@@ -128,8 +140,8 @@ class OpenFeatureClient:
         self,
         flag_key: str,
         default_value: int,
-        evaluation_context: EvaluationContext = None,
-        flag_evaluation_options: FlagEvaluationOptions = None,
+        evaluation_context: typing.Optional[EvaluationContext] = None,
+        flag_evaluation_options: typing.Optional[FlagEvaluationOptions] = None,
     ) -> FlagEvaluationDetails:
         return self.evaluate_flag_details(
             FlagType.INTEGER,
@@ -143,8 +155,8 @@ class OpenFeatureClient:
         self,
         flag_key: str,
         default_value: float,
-        evaluation_context: EvaluationContext = None,
-        flag_evaluation_options: FlagEvaluationOptions = None,
+        evaluation_context: typing.Optional[EvaluationContext] = None,
+        flag_evaluation_options: typing.Optional[FlagEvaluationOptions] = None,
     ) -> float:
         return self.get_float_details(
             flag_key,
@@ -157,8 +169,8 @@ class OpenFeatureClient:
         self,
         flag_key: str,
         default_value: float,
-        evaluation_context: EvaluationContext = None,
-        flag_evaluation_options: FlagEvaluationOptions = None,
+        evaluation_context: typing.Optional[EvaluationContext] = None,
+        flag_evaluation_options: typing.Optional[FlagEvaluationOptions] = None,
     ) -> FlagEvaluationDetails:
         return self.evaluate_flag_details(
             FlagType.FLOAT,
@@ -172,8 +184,8 @@ class OpenFeatureClient:
         self,
         flag_key: str,
         default_value: dict,
-        evaluation_context: EvaluationContext = None,
-        flag_evaluation_options: FlagEvaluationOptions = None,
+        evaluation_context: typing.Optional[EvaluationContext] = None,
+        flag_evaluation_options: typing.Optional[FlagEvaluationOptions] = None,
     ) -> dict:
         return self.evaluate_flag_details(
             FlagType.OBJECT,
@@ -187,8 +199,8 @@ class OpenFeatureClient:
         self,
         flag_key: str,
         default_value: dict,
-        evaluation_context: EvaluationContext = None,
-        flag_evaluation_options: FlagEvaluationOptions = None,
+        evaluation_context: typing.Optional[EvaluationContext] = None,
+        flag_evaluation_options: typing.Optional[FlagEvaluationOptions] = None,
     ) -> FlagEvaluationDetails:
         return self.evaluate_flag_details(
             FlagType.OBJECT,
@@ -203,8 +215,8 @@ class OpenFeatureClient:
         flag_type: FlagType,
         flag_key: str,
         default_value: typing.Any,
-        evaluation_context: EvaluationContext = None,
-        flag_evaluation_options: FlagEvaluationOptions = None,
+        evaluation_context: typing.Optional[EvaluationContext] = None,
+        flag_evaluation_options: typing.Optional[FlagEvaluationOptions] = None,
     ) -> FlagEvaluationDetails:
         """
         Evaluate the flag requested by the user from the clients provider.
@@ -307,7 +319,7 @@ class OpenFeatureClient:
         flag_type: FlagType,
         flag_key: str,
         default_value: typing.Any,
-        evaluation_context: EvaluationContext = None,
+        evaluation_context: typing.Optional[EvaluationContext] = None,
     ) -> FlagEvaluationDetails:
         """
         Encapsulated method to create a FlagEvaluationDetail from a specific provider.
@@ -329,16 +341,15 @@ class OpenFeatureClient:
             logging.info("No provider configured, using no-op provider.")
             self.provider = NoOpProvider()
 
-        get_details_callable = {
+        get_details_callables: typing.Mapping[FlagType, GetDetailCallable] = {
             FlagType.BOOLEAN: self.provider.resolve_boolean_details,
             FlagType.INTEGER: self.provider.resolve_integer_details,
             FlagType.FLOAT: self.provider.resolve_float_details,
             FlagType.OBJECT: self.provider.resolve_object_details,
             FlagType.STRING: self.provider.resolve_string_details,
-        }.get(flag_type)
+        }
 
         get_details_callable = get_details_callables.get(flag_type)
-
         if not get_details_callable:
             raise GeneralError(error_message="Unknown flag type")
 

--- a/open_feature/open_feature_client.py
+++ b/open_feature/open_feature_client.py
@@ -8,6 +8,8 @@ from open_feature.exception.exceptions import (
     OpenFeatureError,
     TypeMismatchError,
 )
+from open_feature.exception.exceptions import GeneralError
+from open_feature.flag_evaluation.error_code import ErrorCode
 from open_feature.flag_evaluation.flag_evaluation_details import FlagEvaluationDetails
 from open_feature.flag_evaluation.flag_evaluation_options import FlagEvaluationOptions
 from open_feature.flag_evaluation.flag_type import FlagType

--- a/open_feature/open_feature_client.py
+++ b/open_feature/open_feature_client.py
@@ -25,6 +25,9 @@ from open_feature.provider.no_op_provider import NoOpProvider
 from open_feature.provider.provider import AbstractProvider
 
 NUMERIC_TYPES = [FlagType.FLOAT, FlagType.INTEGER]
+GetDetailsCallable = typing.Callable[
+    [str, typing.Any, typing.Optional[EvaluationContext]], FlagEvaluationDetails
+]
 
 
 class OpenFeatureClient:
@@ -331,6 +334,8 @@ class OpenFeatureClient:
             FlagType.OBJECT: self.provider.resolve_object_details,
             FlagType.STRING: self.provider.resolve_string_details,
         }.get(flag_type)
+
+        get_details_callable = get_details_callables.get(flag_type)
 
         if not get_details_callable:
             raise GeneralError(error_message="Unknown flag type")

--- a/open_feature/provider/no_op_provider.py
+++ b/open_feature/provider/no_op_provider.py
@@ -22,7 +22,7 @@ class NoOpProvider(AbstractProvider):
         self,
         flag_key: str,
         default_value: bool,
-        evaluation_context: EvaluationContext = None,
+        evaluation_context: Optional[EvaluationContext] = None,
     ):
         return FlagEvaluationDetails(
             flag_key=flag_key,
@@ -35,7 +35,7 @@ class NoOpProvider(AbstractProvider):
         self,
         flag_key: str,
         default_value: str,
-        evaluation_context: EvaluationContext = None,
+        evaluation_context: Optional[EvaluationContext] = None,
     ):
         return FlagEvaluationDetails(
             flag_key=flag_key,
@@ -74,7 +74,7 @@ class NoOpProvider(AbstractProvider):
         self,
         flag_key: str,
         default_value: dict,
-        evaluation_context: EvaluationContext = None,
+        evaluation_context: Optional[EvaluationContext] = None,
     ):
         return FlagEvaluationDetails(
             flag_key=flag_key,

--- a/open_feature/provider/no_op_provider.py
+++ b/open_feature/provider/no_op_provider.py
@@ -22,8 +22,8 @@ class NoOpProvider(AbstractProvider):
         self,
         flag_key: str,
         default_value: bool,
-        evaluation_context: Optional[EvaluationContext] = None,
-    ):
+        evaluation_context: typing.Optional[EvaluationContext] = None,
+    ) -> FlagEvaluationDetails[bool]:
         return FlagEvaluationDetails(
             flag_key=flag_key,
             value=default_value,
@@ -35,8 +35,8 @@ class NoOpProvider(AbstractProvider):
         self,
         flag_key: str,
         default_value: str,
-        evaluation_context: Optional[EvaluationContext] = None,
-    ):
+        evaluation_context: typing.Optional[EvaluationContext] = None,
+    ) -> FlagEvaluationDetails[str]:
         return FlagEvaluationDetails(
             flag_key=flag_key,
             value=default_value,
@@ -48,8 +48,8 @@ class NoOpProvider(AbstractProvider):
         self,
         flag_key: str,
         default_value: int,
-        evaluation_context: EvaluationContext = None,
-    ):
+        evaluation_context: typing.Optional[EvaluationContext] = None,
+    ) -> FlagEvaluationDetails[int]:
         return FlagEvaluationDetails(
             flag_key=flag_key,
             value=default_value,
@@ -61,8 +61,8 @@ class NoOpProvider(AbstractProvider):
         self,
         flag_key: str,
         default_value: float,
-        evaluation_context: EvaluationContext = None,
-    ):
+        evaluation_context: typing.Optional[EvaluationContext] = None,
+    ) -> FlagEvaluationDetails[float]:
         return FlagEvaluationDetails(
             flag_key=flag_key,
             value=default_value,
@@ -74,8 +74,8 @@ class NoOpProvider(AbstractProvider):
         self,
         flag_key: str,
         default_value: dict,
-        evaluation_context: Optional[EvaluationContext] = None,
-    ):
+        evaluation_context: typing.Optional[EvaluationContext] = None,
+    ) -> FlagEvaluationDetails[dict]:
         return FlagEvaluationDetails(
             flag_key=flag_key,
             value=default_value,

--- a/open_feature/provider/provider.py
+++ b/open_feature/provider/provider.py
@@ -1,5 +1,7 @@
 import typing
 from abc import abstractmethod
+from numbers import Number
+from typing import Optional
 
 from open_feature.evaluation_context.evaluation_context import EvaluationContext
 from open_feature.hooks.hook import Hook
@@ -20,7 +22,7 @@ class AbstractProvider:
         self,
         flag_key: str,
         default_value: bool,
-        evaluation_context: EvaluationContext = EvaluationContext(),
+        evaluation_context: Optional[EvaluationContext] = None,
     ):
         pass
 
@@ -29,7 +31,7 @@ class AbstractProvider:
         self,
         flag_key: str,
         default_value: str,
-        evaluation_context: EvaluationContext = EvaluationContext(),
+        evaluation_context: Optional[EvaluationContext] = None,
     ):
         pass
 
@@ -56,6 +58,6 @@ class AbstractProvider:
         self,
         flag_key: str,
         default_value: dict,
-        evaluation_context: EvaluationContext = EvaluationContext(),
+        evaluation_context: Optional[EvaluationContext] = None,
     ):
         pass

--- a/open_feature/provider/provider.py
+++ b/open_feature/provider/provider.py
@@ -1,9 +1,8 @@
 import typing
 from abc import abstractmethod
-from numbers import Number
-from typing import Optional
 
 from open_feature.evaluation_context.evaluation_context import EvaluationContext
+from open_feature.flag_evaluation.flag_evaluation_details import FlagEvaluationDetails
 from open_feature.hooks.hook import Hook
 from open_feature.provider.metadata import Metadata
 
@@ -22,8 +21,8 @@ class AbstractProvider:
         self,
         flag_key: str,
         default_value: bool,
-        evaluation_context: Optional[EvaluationContext] = None,
-    ):
+        evaluation_context: typing.Optional[EvaluationContext] = None,
+    ) -> FlagEvaluationDetails[bool]:
         pass
 
     @abstractmethod
@@ -31,8 +30,8 @@ class AbstractProvider:
         self,
         flag_key: str,
         default_value: str,
-        evaluation_context: Optional[EvaluationContext] = None,
-    ):
+        evaluation_context: typing.Optional[EvaluationContext] = None,
+    ) -> FlagEvaluationDetails[str]:
         pass
 
     @abstractmethod
@@ -40,8 +39,8 @@ class AbstractProvider:
         self,
         flag_key: str,
         default_value: int,
-        evaluation_context: EvaluationContext = EvaluationContext(),
-    ):
+        evaluation_context: typing.Optional[EvaluationContext] = None,
+    ) -> FlagEvaluationDetails[int]:
         pass
 
     @abstractmethod
@@ -49,8 +48,8 @@ class AbstractProvider:
         self,
         flag_key: str,
         default_value: float,
-        evaluation_context: EvaluationContext = EvaluationContext(),
-    ):
+        evaluation_context: typing.Optional[EvaluationContext] = None,
+    ) -> FlagEvaluationDetails[float]:
         pass
 
     @abstractmethod
@@ -58,6 +57,6 @@ class AbstractProvider:
         self,
         flag_key: str,
         default_value: dict,
-        evaluation_context: Optional[EvaluationContext] = None,
-    ):
+        evaluation_context: typing.Optional[EvaluationContext] = None,
+    ) -> FlagEvaluationDetails[dict]:
         pass

--- a/tests/test_open_feature_client.py
+++ b/tests/test_open_feature_client.py
@@ -108,7 +108,7 @@ def test_should_handle_an_open_feature_exception_thrown_by_a_provider(
     # Given
     exception_hook = MagicMock(spec=Hook)
     exception_hook.after.side_effect = OpenFeatureError(
-        "error_message", ErrorCode.GENERAL
+        ErrorCode.GENERAL, "error_message"
     )
     no_op_provider_client.add_hooks([exception_hook])
 


### PR DESCRIPTION
Signed-off-by: Manuel Schönlaub <manuel.schoenlaub@gmail.com>

## This PR
This PR fixes typing errors in the client code:

1. The Liskov Substitution Principle should also apply to providers. This relates to the signature of the methods to retrieve flags.

2. Incorrect usage of `type` instead of `flagType`. Most probably a typo.

3. Ensure that the callables in `create_provider_evaluation` are annotated in a `mypy`-friendly way.

4. Fix type annotations for `FlagEvaluationDetails`

5. Fix type annotations around optional parameters all over the place

### Related Issues
Fixes #17 
