### PR TITLE
fix/flag-error-message: Move flag evaluation details to a dataclass

### DIFF
--- a/open_feature/flag_evaluation/flag_evaluation_details.py
+++ b/open_feature/flag_evaluation/flag_evaluation_details.py
@@ -1,18 +1,15 @@
+import typing
+from dataclasses import dataclass
+
 from open_feature.flag_evaluation.error_code import ErrorCode
 from open_feature.flag_evaluation.reason import Reason
 
 
+@dataclass
 class FlagEvaluationDetails:
-    def __init__(
-        self,
-        key: str,
-        value,
-        reason: Reason,
-        error_code: ErrorCode = None,
-        variant=None,
-    ):
-        self.key = key
-        self.value = value
-        self.reason = reason
-        self.error_code = error_code
-        self.variant = variant
+    flag_key: str
+    value: typing.Any
+    variant: str = None
+    reason: Reason = None
+    error_code: ErrorCode = None
+    error_message: str = None


### PR DESCRIPTION
## This PR
Move flag evaluation details to a dataclass and add error message to the class

- FlagEvaluationDetails has been moved to a dataclass
- error_message has been added to the FlagEvaluationDetails class
