### PR TITLE
feat: evaluation context serialization

### DIFF
--- a/open_feature/evaluation_context/evaluation_context.py
+++ b/open_feature/evaluation_context/evaluation_context.py
@@ -1,5 +1,6 @@
 import json
 
+
 class EvaluationContext:
     """
     EvaluationContext contains metadata pertaining to the evaluation context
@@ -10,6 +11,7 @@ class EvaluationContext:
     representation of JSON, or you can use the `asdict()` method to generate
     a dictionary of the same structure.
     """
+
     def __init__(self, targeting_key: str = None, attributes: dict = None):
         self.targeting_key = targeting_key
         self.attributes = attributes or {}
@@ -30,5 +32,4 @@ class EvaluationContext:
         return json.dumps(self.asdict(), ensure_ascii=False)
 
     def asdict(self):
-        return {**self.attributes, 'targetingKey': self.targeting_key}
-
+        return {**self.attributes, "targetingKey": self.targeting_key}

--- a/open_feature/evaluation_context/evaluation_context.py
+++ b/open_feature/evaluation_context/evaluation_context.py
@@ -14,8 +14,14 @@ class EvaluationContext:
 
         return self
 
+    def __str__(self):
+        return self.__repr__()
+
+    def __repr__(self):
+        return json.dumps(self.asdict(), ensure_ascii=False)
+
     def asdict(self):
         return {**self.attributes, 'targetingKey': self.targeting_key}
-    
+
     def to_json(self):
         return json.dumps(self.asdict())

--- a/open_feature/evaluation_context/evaluation_context.py
+++ b/open_feature/evaluation_context/evaluation_context.py
@@ -1,6 +1,15 @@
 import json
 
 class EvaluationContext:
+    """
+    EvaluationContext contains metadata pertaining to the evaluation context
+    of the flag resolution. This is typically handled within providers which
+    may need to make requests to external resources.
+
+    To serialize, you can use `str` or `repr` built-ins to generate a string
+    representation of JSON, or you can use the `asdict()` method to generate
+    a dictionary of the same structure.
+    """
     def __init__(self, targeting_key: str = None, attributes: dict = None):
         self.targeting_key = targeting_key
         self.attributes = attributes or {}
@@ -23,5 +32,3 @@ class EvaluationContext:
     def asdict(self):
         return {**self.attributes, 'targetingKey': self.targeting_key}
 
-    def to_json(self):
-        return json.dumps(self.asdict())

--- a/open_feature/evaluation_context/evaluation_context.py
+++ b/open_feature/evaluation_context/evaluation_context.py
@@ -1,3 +1,5 @@
+import json
+
 class EvaluationContext:
     def __init__(self, targeting_key: str = None, attributes: dict = None):
         self.targeting_key = targeting_key
@@ -11,3 +13,9 @@ class EvaluationContext:
         self.targeting_key = ctx2.targeting_key or self.targeting_key
 
         return self
+
+    def asdict(self):
+        return {**self.attributes, 'targetingKey': self.targeting_key}
+    
+    def to_json(self):
+        return json.dumps(self.asdict())

--- a/tests/evaluation_context/test_evaluation_context.py
+++ b/tests/evaluation_context/test_evaluation_context.py
@@ -47,6 +47,7 @@ def test_second_targeting_key_overwrites_first():
     # Then
     assert merged_context.targeting_key == second_context.targeting_key
 
+
 def test_can_cast_to_dict():
     # Given
     context = EvaluationContext(
@@ -59,6 +60,7 @@ def test_can_cast_to_dict():
     # Then
     assert context_dict == {"targetingKey": "targeting_key", "att1": "value1"}
 
+
 def test_can_str_to_json():
     # Given
     context = EvaluationContext(
@@ -70,6 +72,7 @@ def test_can_str_to_json():
 
     # Then
     assert context_dict == '{"att1": "value1", "targetingKey": "targeting_key"}'
+
 
 def test_can_repr_to_json():
     # Given

--- a/tests/evaluation_context/test_evaluation_context.py
+++ b/tests/evaluation_context/test_evaluation_context.py
@@ -66,7 +66,7 @@ def test_can_serialize_to_json_string():
     )
 
     # When
-    context_dict = context.to_json()
+    context_dict = str(context)
 
     # Then
     assert context_dict == '{"att1": "value1", "targetingKey": "targeting_key"}'

--- a/tests/evaluation_context/test_evaluation_context.py
+++ b/tests/evaluation_context/test_evaluation_context.py
@@ -1,3 +1,4 @@
+import json
 from open_feature.evaluation_context.evaluation_context import EvaluationContext
 
 
@@ -45,3 +46,27 @@ def test_second_targeting_key_overwrites_first():
 
     # Then
     assert merged_context.targeting_key == second_context.targeting_key
+
+def test_can_cast_to_dict():
+    # Given
+    context = EvaluationContext(
+        targeting_key="targeting_key", attributes={"att1": "value1"}
+    )
+
+    # When
+    context_dict = context.asdict()
+
+    # Then
+    assert context_dict == {"targetingKey": "targeting_key", "att1": "value1"}
+
+def test_can_serialize_to_json_string():
+    # Given
+    context = EvaluationContext(
+        targeting_key="targeting_key", attributes={"att1": "value1"}
+    )
+
+    # When
+    context_dict = context.to_json()
+
+    # Then
+    assert context_dict == '{"att1": "value1", "targetingKey": "targeting_key"}'

--- a/tests/evaluation_context/test_evaluation_context.py
+++ b/tests/evaluation_context/test_evaluation_context.py
@@ -1,4 +1,3 @@
-import json
 from open_feature.evaluation_context.evaluation_context import EvaluationContext
 
 

--- a/tests/evaluation_context/test_evaluation_context.py
+++ b/tests/evaluation_context/test_evaluation_context.py
@@ -59,7 +59,7 @@ def test_can_cast_to_dict():
     # Then
     assert context_dict == {"targetingKey": "targeting_key", "att1": "value1"}
 
-def test_can_serialize_to_json_string():
+def test_can_str_to_json():
     # Given
     context = EvaluationContext(
         targeting_key="targeting_key", attributes={"att1": "value1"}
@@ -67,6 +67,18 @@ def test_can_serialize_to_json_string():
 
     # When
     context_dict = str(context)
+
+    # Then
+    assert context_dict == '{"att1": "value1", "targetingKey": "targeting_key"}'
+
+def test_can_repr_to_json():
+    # Given
+    context = EvaluationContext(
+        targeting_key="targeting_key", attributes={"att1": "value1"}
+    )
+
+    # When
+    context_dict = repr(context)
 
     # Then
     assert context_dict == '{"att1": "value1", "targetingKey": "targeting_key"}'


### PR DESCRIPTION


<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- adds the ability to transform evaluation context consistently
    - transform to dictionary
    - stringify json

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

For consumers like `python-sdk-contrib` this will provide a consistent way to convert the evaluation context to JSON or a dictionary for use in any way. Follows the same structure as `js-sdk` in that `targetingKey` and the rest of the attributes are joined at the top-level.

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

Unit tests :100: 
