### PR TITLE
fix: Get Object should return both list and dict

### DIFF
--- a/open_feature/flag_evaluation/flag_type.py
+++ b/open_feature/flag_evaluation/flag_type.py
@@ -1,9 +1,10 @@
+import typing
 from enum import Enum
 
 
 class FlagType(Enum):
     BOOLEAN = bool
     STRING = str
-    OBJECT = dict
+    OBJECT = typing.Union[dict, list]
     FLOAT = float
     INTEGER = int

--- a/open_feature/open_feature_client.py
+++ b/open_feature/open_feature_client.py
@@ -359,8 +359,9 @@ class OpenFeatureClient:
         value = get_details_callable(*args)
 
         # we need to check the get_args to be compatible with union types.
-        is_right_instance = isinstance(value.value, typing.get_args(flag_type.value)) \
-                            or isinstance(value.value, flag_type.value)
+        is_right_instance = isinstance(
+            value.value, typing.get_args(flag_type.value)
+        ) or isinstance(value.value, flag_type.value)
         if not is_right_instance:
             raise TypeMismatchError()
 

--- a/open_feature/open_feature_client.py
+++ b/open_feature/open_feature_client.py
@@ -358,7 +358,10 @@ class OpenFeatureClient:
 
         value = get_details_callable(*args)
 
-        if not isinstance(value.value, flag_type.value):
+        # we need to check the get_args to be compatible with union types.
+        is_right_instance = isinstance(value.value, typing.get_args(flag_type.value)) \
+                            or isinstance(value.value, flag_type.value)
+        if not is_right_instance:
             raise TypeMismatchError()
 
         return value

--- a/open_feature/provider/no_op_provider.py
+++ b/open_feature/provider/no_op_provider.py
@@ -73,9 +73,9 @@ class NoOpProvider(AbstractProvider):
     def resolve_object_details(
         self,
         flag_key: str,
-        default_value: dict,
+        default_value: typing.Union[dict, list],
         evaluation_context: typing.Optional[EvaluationContext] = None,
-    ) -> FlagEvaluationDetails[dict]:
+    ) -> FlagEvaluationDetails[typing.Union[dict, list]]:
         return FlagEvaluationDetails(
             flag_key=flag_key,
             value=default_value,

--- a/open_feature/provider/provider.py
+++ b/open_feature/provider/provider.py
@@ -56,7 +56,7 @@ class AbstractProvider:
     def resolve_object_details(
         self,
         flag_key: str,
-        default_value: dict,
+        default_value: typing.Union[dict, list],
         evaluation_context: typing.Optional[EvaluationContext] = None,
-    ) -> FlagEvaluationDetails[dict]:
+    ) -> FlagEvaluationDetails[typing.Union[dict, list]]:
         pass

--- a/tests/provider/test_no_op_provider.py
+++ b/tests/provider/test_no_op_provider.py
@@ -56,7 +56,9 @@ def test_should_resolve_string_flag_from_no_op():
 def test_should_resolve_list_flag_from_no_op():
     # Given
     # When
-    flag = NoOpProvider().resolve_object_details(flag_key="Key", default_value=["item1", "item2"])
+    flag = NoOpProvider().resolve_object_details(
+        flag_key="Key", default_value=["item1", "item2"]
+    )
     # Then
     assert flag is not None
     assert flag.value == ["item1", "item2"]

--- a/tests/provider/test_no_op_provider.py
+++ b/tests/provider/test_no_op_provider.py
@@ -53,6 +53,16 @@ def test_should_resolve_string_flag_from_no_op():
     assert isinstance(flag.value, str)
 
 
+def test_should_resolve_list_flag_from_no_op():
+    # Given
+    # When
+    flag = NoOpProvider().resolve_object_details(flag_key="Key", default_value=["item1", "item2"])
+    # Then
+    assert flag is not None
+    assert flag.value == ["item1", "item2"]
+    assert isinstance(flag.value, list)
+
+
 def test_should_resolve_object_flag_from_no_op():
     # Given
     return_value = {

--- a/tests/test_open_feature_client.py
+++ b/tests/test_open_feature_client.py
@@ -24,6 +24,11 @@ from open_feature.hooks.hook import Hook
             },
             "get_object_value",
         ),
+        (
+            list,
+            ["string1", "string2"],
+            "get_object_value",
+        ),
     ),
 )
 def test_should_get_flag_value_based_on_method_type(


### PR DESCRIPTION
## This PR
- add the possibility for providers to return both `dict` and `list` while calling `get_object_*` functions.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #63

