### PR TITLE
feat: defaults to NoOpProvider

### DIFF
--- a/open_feature/open_feature_api.py
+++ b/open_feature/open_feature_api.py
@@ -2,18 +2,15 @@ import typing
 
 from open_feature.exception.exceptions import GeneralError
 from open_feature.open_feature_client import OpenFeatureClient
+from open_feature.provider.no_op_provider import NoOpProvider
 from open_feature.provider.provider import AbstractProvider
 
-_provider: typing.Optional[AbstractProvider] = None
+_provider: AbstractProvider = NoOpProvider()
 
 
 def get_client(
     name: typing.Optional[str] = None, version: typing.Optional[str] = None
 ) -> OpenFeatureClient:
-    if _provider is None:
-        raise GeneralError(
-            error_message="Provider not set. Call set_provider before using get_client"
-        )
     return OpenFeatureClient(name=name, version=version, provider=_provider)
 
 

--- a/tests/test_open_feature_api.py
+++ b/tests/test_open_feature_api.py
@@ -6,7 +6,7 @@ from open_feature.open_feature_api import get_client, get_provider, set_provider
 from open_feature.provider.no_op_provider import NoOpProvider
 
 
-def test_should_not_raise_exception_with_nop_client():
+def test_should_not_raise_exception_with_noop_client():
     # Given
     # No provider has been set
     # When

--- a/tests/test_open_feature_api.py
+++ b/tests/test_open_feature_api.py
@@ -6,18 +6,16 @@ from open_feature.open_feature_api import get_client, get_provider, set_provider
 from open_feature.provider.no_op_provider import NoOpProvider
 
 
-def test_should_raise_exception_with_nop_client():
+def test_should_not_raise_exception_with_nop_client():
     # Given
+    # No provider has been set
     # When
-    with pytest.raises(GeneralError) as ge:
-        get_client()
+    client = get_client(name="Default Provider", version="1.0")
+
     # Then
-    assert ge.value
-    assert (
-        ge.value.error_message
-        == "Provider not set. Call set_provider before using get_client"
-    )
-    assert ge.value.error_code == ErrorCode.GENERAL
+    assert client.name == "Default Provider"
+    assert client.version == "1.0"
+    assert isinstance(client.provider, NoOpProvider)
 
 
 def test_should_return_open_feature_client_when_configured_correctly():


### PR DESCRIPTION
## This PR

- initial provider set to a NoOpProvider
- ensures a client will always be returned even if a provider has not been explicitly set

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #1234523

### Notes

This fixes an issue with spec compliance

### Follow-up Tasks

~~- Tests~~

### How to test

Given you have not set a provider
When you retrieve an OpenFeature client
Then an error will not be raised

