### PR TITLE
fix: reverse the merged before hooks

### DIFF
--- a/open_feature/open_feature_client.py
+++ b/open_feature/open_feature_client.py
@@ -256,7 +256,7 @@ class OpenFeatureClient:
         )
         # after, error, finally: Provider, Invocation, Client, API
         reversed_merged_hooks = merged_hooks[:]
-        reversed_merged_hooks.sort()
+        reversed_merged_hooks.reverse()
 
         try:
             # https://github.com/open-feature/spec/blob/main/specification/sections/03-evaluation-context.md


### PR DESCRIPTION
## This PR

- the copied `before` hooks array is not reversed

### Related Issues

### Notes

### Follow-up Tasks

Tests

### How to test
