### PR TITLE
chore: Add alternative pip file names to renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
-  ]
+  ],
+  "pip_requirements": {
+    "fileMatch": ["requirements.txt", "requirements-dev.txt"]
+  }
 }


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- Explicitly add `requirements-dev.txt` to Renovate config

### Notes

Renovate isn't detecting the dev dependences because it only looks at `requirements.txt` by default. This can be addressed by added `pip_requirements` as described [here](https://docs.renovatebot.com/python/#alternative-file-names). The currently detected dependencies can be seen [in this issue](https://github.com/open-feature/python-sdk/issues/36).


Signed-off-by: Michael Beemer <beeme1mr@users.noreply.github.com>