### PR TITLE
chore: split eval and resolution details objects, adjust providers accordingly

### DIFF
--- a/open_feature/flag_evaluation/resolution_details.py
+++ b/open_feature/flag_evaluation/resolution_details.py
@@ -1,0 +1,17 @@
+import typing
+from dataclasses import dataclass
+
+from open_feature.exception.error_code import ErrorCode
+from open_feature.flag_evaluation.reason import Reason
+
+T = typing.TypeVar("T", covariant=True)
+
+
+@dataclass
+class FlagResolutionDetails(typing.Generic[T]):
+    value: T
+    error_code: typing.Optional[ErrorCode] = None
+    error_message: typing.Optional[str] = None
+    reason: typing.Optional[Reason] = None
+    variant: typing.Optional[str] = None
+    flag_metadata: typing.Optional[str] = None

--- a/open_feature/provider/no_op_provider.py
+++ b/open_feature/provider/no_op_provider.py
@@ -1,7 +1,6 @@
 import typing
 
 from open_feature.evaluation_context.evaluation_context import EvaluationContext
-from open_feature.flag_evaluation.flag_evaluation_details import FlagEvaluationDetails
 from open_feature.flag_evaluation.reason import Reason
 from open_feature.flag_evaluation.resolution_details import FlagResolutionDetails
 from open_feature.hooks.hook import Hook

--- a/open_feature/provider/no_op_provider.py
+++ b/open_feature/provider/no_op_provider.py
@@ -3,6 +3,7 @@ import typing
 from open_feature.evaluation_context.evaluation_context import EvaluationContext
 from open_feature.flag_evaluation.flag_evaluation_details import FlagEvaluationDetails
 from open_feature.flag_evaluation.reason import Reason
+from open_feature.flag_evaluation.resolution_details import FlagResolutionDetails
 from open_feature.hooks.hook import Hook
 from open_feature.provider.metadata import Metadata
 from open_feature.provider.no_op_metadata import NoOpMetadata
@@ -23,9 +24,8 @@ class NoOpProvider(AbstractProvider):
         flag_key: str,
         default_value: bool,
         evaluation_context: typing.Optional[EvaluationContext] = None,
-    ) -> FlagEvaluationDetails[bool]:
-        return FlagEvaluationDetails(
-            flag_key=flag_key,
+    ) -> FlagResolutionDetails[bool]:
+        return FlagResolutionDetails(
             value=default_value,
             reason=Reason.DEFAULT,
             variant=PASSED_IN_DEFAULT,
@@ -36,9 +36,8 @@ class NoOpProvider(AbstractProvider):
         flag_key: str,
         default_value: str,
         evaluation_context: typing.Optional[EvaluationContext] = None,
-    ) -> FlagEvaluationDetails[str]:
-        return FlagEvaluationDetails(
-            flag_key=flag_key,
+    ) -> FlagResolutionDetails[str]:
+        return FlagResolutionDetails(
             value=default_value,
             reason=Reason.DEFAULT,
             variant=PASSED_IN_DEFAULT,
@@ -49,9 +48,8 @@ class NoOpProvider(AbstractProvider):
         flag_key: str,
         default_value: int,
         evaluation_context: typing.Optional[EvaluationContext] = None,
-    ) -> FlagEvaluationDetails[int]:
-        return FlagEvaluationDetails(
-            flag_key=flag_key,
+    ) -> FlagResolutionDetails[int]:
+        return FlagResolutionDetails(
             value=default_value,
             reason=Reason.DEFAULT,
             variant=PASSED_IN_DEFAULT,
@@ -62,9 +60,8 @@ class NoOpProvider(AbstractProvider):
         flag_key: str,
         default_value: float,
         evaluation_context: typing.Optional[EvaluationContext] = None,
-    ) -> FlagEvaluationDetails[float]:
-        return FlagEvaluationDetails(
-            flag_key=flag_key,
+    ) -> FlagResolutionDetails[float]:
+        return FlagResolutionDetails(
             value=default_value,
             reason=Reason.DEFAULT,
             variant=PASSED_IN_DEFAULT,
@@ -75,9 +72,8 @@ class NoOpProvider(AbstractProvider):
         flag_key: str,
         default_value: typing.Union[dict, list],
         evaluation_context: typing.Optional[EvaluationContext] = None,
-    ) -> FlagEvaluationDetails[typing.Union[dict, list]]:
-        return FlagEvaluationDetails(
-            flag_key=flag_key,
+    ) -> FlagResolutionDetails[typing.Union[dict, list]]:
+        return FlagResolutionDetails(
             value=default_value,
             reason=Reason.DEFAULT,
             variant=PASSED_IN_DEFAULT,

--- a/open_feature/provider/provider.py
+++ b/open_feature/provider/provider.py
@@ -2,7 +2,7 @@ import typing
 from abc import abstractmethod
 
 from open_feature.evaluation_context.evaluation_context import EvaluationContext
-from open_feature.flag_evaluation.flag_evaluation_details import FlagEvaluationDetails
+from open_feature.flag_evaluation.resolution_details import FlagResolutionDetails
 from open_feature.hooks.hook import Hook
 from open_feature.provider.metadata import Metadata
 
@@ -22,7 +22,7 @@ class AbstractProvider:
         flag_key: str,
         default_value: bool,
         evaluation_context: typing.Optional[EvaluationContext] = None,
-    ) -> FlagEvaluationDetails[bool]:
+    ) -> FlagResolutionDetails[bool]:
         pass
 
     @abstractmethod
@@ -31,7 +31,7 @@ class AbstractProvider:
         flag_key: str,
         default_value: str,
         evaluation_context: typing.Optional[EvaluationContext] = None,
-    ) -> FlagEvaluationDetails[str]:
+    ) -> FlagResolutionDetails[str]:
         pass
 
     @abstractmethod
@@ -40,7 +40,7 @@ class AbstractProvider:
         flag_key: str,
         default_value: int,
         evaluation_context: typing.Optional[EvaluationContext] = None,
-    ) -> FlagEvaluationDetails[int]:
+    ) -> FlagResolutionDetails[int]:
         pass
 
     @abstractmethod
@@ -49,7 +49,7 @@ class AbstractProvider:
         flag_key: str,
         default_value: float,
         evaluation_context: typing.Optional[EvaluationContext] = None,
-    ) -> FlagEvaluationDetails[float]:
+    ) -> FlagResolutionDetails[float]:
         pass
 
     @abstractmethod
@@ -58,5 +58,5 @@ class AbstractProvider:
         flag_key: str,
         default_value: typing.Union[dict, list],
         evaluation_context: typing.Optional[EvaluationContext] = None,
-    ) -> FlagEvaluationDetails[typing.Union[dict, list]]:
+    ) -> FlagResolutionDetails[typing.Union[dict, list]]:
         pass


### PR DESCRIPTION
### This PR
- adds a new `FlagResolutionDetails` class according to the spec
- makes use of the new class in the abstract provider and the no_op provider instead of using `EvaluationDetails`

Fixes #97