### PR TITLE
feat!: EvaluationDetails.reason should be a string, Reason enum should export default reasons per spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,11 @@ init: .venv
 
 .PHONY: test
 test: .venv
+ifdef TEST
+	$(VENV); pytest $(TEST)
+else
 	$(VENV); pytest
+endif
 
 .PHONY: lint
 lint: .venv

--- a/open_feature/flag_evaluation/flag_evaluation_details.py
+++ b/open_feature/flag_evaluation/flag_evaluation_details.py
@@ -15,3 +15,11 @@ class FlagEvaluationDetails(typing.Generic[T]):
     reason: typing.Optional[Reason] = None
     error_code: typing.Optional[ErrorCode] = None
     error_message: typing.Optional[str] = None
+
+    @property
+    def reason(self) -> str:
+        return self._reason.value
+
+    @reason.setter
+    def reason(self, reason: Reason):
+        self._reason = reason

--- a/open_feature/flag_evaluation/reason.py
+++ b/open_feature/flag_evaluation/reason.py
@@ -2,9 +2,11 @@ from enum import Enum
 
 
 class Reason(Enum):
+    CACHED = "CACHED"
+    DEFAULT = "DEFAULT"
     DISABLED = "DISABLED"
+    ERROR = "ERROR"
+    STATIC = "STATIC"
     SPLIT = "SPLIT"
     TARGETING_MATCH = "TARGETING_MATCH"
-    DEFAULT = "DEFAULT"
     UNKNOWN = "UNKNOWN"
-    ERROR = "ERROR"

--- a/tests/test_open_feature_client.py
+++ b/tests/test_open_feature_client.py
@@ -87,7 +87,7 @@ def test_should_raise_exception_when_invalid_flag_type_provided(no_op_provider_c
     assert flag.value
     assert flag.error_message == "Unknown flag type"
     assert flag.error_code == ErrorCode.GENERAL
-    assert flag.reason == Reason.ERROR
+    assert flag.reason == Reason.ERROR.value
 
 
 def test_should_handle_a_generic_exception_thrown_by_a_provider(no_op_provider_client):
@@ -103,7 +103,7 @@ def test_should_handle_a_generic_exception_thrown_by_a_provider(no_op_provider_c
     assert flag_details is not None
     assert flag_details.value
     assert isinstance(flag_details.value, bool)
-    assert flag_details.reason == Reason.ERROR
+    assert flag_details.reason == Reason.ERROR.value
     assert flag_details.error_message == "Generic exception raised"
 
 
@@ -125,5 +125,5 @@ def test_should_handle_an_open_feature_exception_thrown_by_a_provider(
     assert flag_details is not None
     assert flag_details.value
     assert isinstance(flag_details.value, bool)
-    assert flag_details.reason == Reason.ERROR
+    assert flag_details.reason == Reason.ERROR.value
     assert flag_details.error_message == "error_message"

--- a/tests/test_open_feature_flag_evaluation.py
+++ b/tests/test_open_feature_flag_evaluation.py
@@ -1,0 +1,55 @@
+from open_feature.exception.error_code import ErrorCode
+from open_feature.flag_evaluation.flag_evaluation_details import FlagEvaluationDetails
+from open_feature.flag_evaluation.reason import Reason
+
+
+def test_evaulation_details_reason_should_be_a_string():
+    # Given
+    flag_key = "my-flag"
+    flag_value = 100
+    variant = "1-hundred"
+    reason = Reason.DEFAULT
+    error_code = ErrorCode.GENERAL
+    error_message = "message"
+
+    # When
+    flag_details = FlagEvaluationDetails(
+        flag_key,
+        flag_value,
+        variant,
+        reason,
+        error_code,
+        error_message,
+    )
+
+    # Then
+    assert flag_key == flag_details.flag_key
+    assert flag_value == flag_details.value
+    assert variant == flag_details.variant
+    assert error_code == flag_details.error_code
+    assert error_message == flag_details.error_message
+    assert reason.value == flag_details.reason
+
+
+def test_evaulation_details_reason_should_be_a_string_when_set():
+    # Given
+    flag_key = "my-flag"
+    flag_value = 100
+    variant = "1-hundred"
+    reason = Reason.DEFAULT
+    error_code = ErrorCode.GENERAL
+    error_message = "message"
+
+    # When
+    flag_details = FlagEvaluationDetails(
+        flag_key,
+        flag_value,
+        variant,
+        reason,
+        error_code,
+        error_message,
+    )
+    flag_details.reason = Reason.STATIC
+
+    # Then
+    assert Reason.STATIC.value == flag_details.reason


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- bring FlagEvaluationDetails in-line with the spec

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #98 

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->
make test TEST=tests/test_open_feature_flag_evaluation.py
