### PR TITLE
fix: object client methods can receive dict or list as default_value

### DIFF
--- a/open_feature/open_feature_client.py
+++ b/open_feature/open_feature_client.py
@@ -182,7 +182,7 @@ class OpenFeatureClient:
     def get_object_value(
         self,
         flag_key: str,
-        default_value: dict,
+        default_value: typing.Union[dict, list],
         evaluation_context: typing.Optional[EvaluationContext] = None,
         flag_evaluation_options: typing.Optional[FlagEvaluationOptions] = None,
     ) -> dict:
@@ -197,7 +197,7 @@ class OpenFeatureClient:
     def get_object_details(
         self,
         flag_key: str,
-        default_value: dict,
+        default_value: typing.Union[dict, list],
         evaluation_context: typing.Optional[EvaluationContext] = None,
         flag_evaluation_options: typing.Optional[FlagEvaluationOptions] = None,
     ) -> FlagEvaluationDetails:

--- a/tests/test_open_feature_client.py
+++ b/tests/test_open_feature_client.py
@@ -61,6 +61,11 @@ def test_should_get_flag_value_based_on_method_type(
             },
             "get_object_details",
         ),
+        (
+            list,
+            ["string1", "string2"],
+            "get_object_details",
+        ),
     ),
 )
 def test_should_get_flag_detail_based_on_method_type(


### PR DESCRIPTION
## This PR

Updates client object methods to accept dict or list as default value.