### PR TITLE
fix: use str values in FlagType enum for easier typing

### DIFF
--- a/open_feature/flag_evaluation/flag_type.py
+++ b/open_feature/flag_evaluation/flag_type.py
@@ -1,10 +1,9 @@
-import typing
 from enum import Enum
 
 
 class FlagType(Enum):
-    BOOLEAN = bool
-    STRING = str
-    OBJECT = typing.Union[dict, list]
-    FLOAT = float
-    INTEGER = int
+    BOOLEAN = "BOOLEAN"
+    STRING = "STRING"
+    OBJECT = "OBJECT"
+    FLOAT = "FLOAT"
+    INTEGER = "INTEGER"


### PR DESCRIPTION
## This PR

Replaces FlagType enum values with standard str objects. Fixes mypy getting tripped up by the definition of FlagType.OBJECT.

### Related Issues

Addresses #135