### PR TITLE
feat: implement get_provider_metadata for requirement 1.1.5

### DIFF
--- a/open_feature/open_feature_api.py
+++ b/open_feature/open_feature_api.py
@@ -2,6 +2,7 @@ import typing
 
 from open_feature.exception.exceptions import GeneralError
 from open_feature.open_feature_client import OpenFeatureClient
+from open_feature.provider.metadata import Metadata
 from open_feature.provider.no_op_provider import NoOpProvider
 from open_feature.provider.provider import AbstractProvider
 
@@ -24,3 +25,8 @@ def set_provider(provider: AbstractProvider):
 def get_provider() -> typing.Optional[AbstractProvider]:
     global _provider
     return _provider
+
+
+def get_provider_metadata() -> typing.Optional[Metadata]:
+    global _provider
+    return _provider.get_metadata()

--- a/tests/test_open_feature_api.py
+++ b/tests/test_open_feature_api.py
@@ -2,7 +2,13 @@ import pytest
 
 from open_feature.exception.error_code import ErrorCode
 from open_feature.exception.exceptions import GeneralError
-from open_feature.open_feature_api import get_client, get_provider, set_provider
+from open_feature.open_feature_api import (
+    get_client,
+    get_provider,
+    set_provider,
+    get_provider_metadata,
+)
+from open_feature.provider.metadata import Metadata
 from open_feature.provider.no_op_provider import NoOpProvider
 
 
@@ -52,3 +58,15 @@ def test_should_return_a_provider_if_setup_correctly():
     # Then
     assert provider
     assert isinstance(provider, NoOpProvider)
+
+
+def test_should_retrieve_metadata_for_configured_provider():
+    # Given
+    set_provider(NoOpProvider())
+
+    # When
+    metadata = get_provider_metadata()
+
+    # Then
+    assert isinstance(metadata, Metadata)
+    assert metadata.name == "No-op Provider"


### PR DESCRIPTION
## This PR

Implements requirement [1.1.5](https://github.com/open-feature/spec/blob/main/specification/sections/01-flag-evaluation.md#requirement-115):

> The API MUST provide a function for retrieving the metadata field of the configured provider.

