### PR TITLE
feat: implement client get_metadata for requirement 1.2.2

### DIFF
--- a/open_feature/open_feature_client.py
+++ b/open_feature/open_feature_client.py
@@ -1,5 +1,6 @@
 import logging
 import typing
+from dataclasses import dataclass
 
 from open_feature.evaluation_context.evaluation_context import EvaluationContext
 from open_feature.exception.error_code import ErrorCode
@@ -45,6 +46,11 @@ GetDetailCallable = typing.Union[
 ]
 
 
+@dataclass
+class ClientMetadata:
+    name: str
+
+
 class OpenFeatureClient:
     def __init__(
         self,
@@ -59,6 +65,9 @@ class OpenFeatureClient:
         self.context = context or EvaluationContext()
         self.hooks = hooks or []
         self.provider = provider
+
+    def get_metadata(self):
+        return ClientMetadata(name=self.name)
 
     def add_hooks(self, hooks: typing.List[Hook]):
         self.hooks = self.hooks + hooks

--- a/tests/test_open_feature_client.py
+++ b/tests/test_open_feature_client.py
@@ -6,6 +6,8 @@ from open_feature.exception.error_code import ErrorCode
 from open_feature.exception.exceptions import OpenFeatureError
 from open_feature.flag_evaluation.reason import Reason
 from open_feature.hooks.hook import Hook
+from open_feature.open_feature_client import OpenFeatureClient
+from open_feature.provider.no_op_provider import NoOpProvider
 
 
 @pytest.mark.parametrize(
@@ -132,3 +134,13 @@ def test_should_handle_an_open_feature_exception_thrown_by_a_provider(
     assert isinstance(flag_details.value, bool)
     assert flag_details.reason == Reason.ERROR.value
     assert flag_details.error_message == "error_message"
+
+
+def test_should_return_client_metadata_with_name():
+    # Given
+    client = OpenFeatureClient("my-client", None, NoOpProvider())
+    # When
+    metadata = client.get_metadata()
+    # Then
+    assert metadata is not None
+    assert metadata.name == "my-client"


### PR DESCRIPTION
## This PR

Implements requirement [1.2.2](https://github.com/open-feature/spec/blob/main/specification/sections/01-flag-evaluation.md#requirement-122):

> The client interface MUST define a metadata member or accessor, containing an immutable name field or accessor of type string, which corresponds to the name value supplied during client creation.