### PR TITLE
refactor: make Reason enum values instances of str

### DIFF
--- a/open_feature/_backports/strenum.py
+++ b/open_feature/_backports/strenum.py
@@ -1,0 +1,11 @@
+try:
+    from enum import StrEnum
+except ImportError:
+    from enum import Enum
+
+    class StrEnum(str, Enum):
+        """
+        Backport StrEnum for Python <3.11
+        """
+
+        pass

--- a/open_feature/flag_evaluation/flag_evaluation_details.py
+++ b/open_feature/flag_evaluation/flag_evaluation_details.py
@@ -15,11 +15,3 @@ class FlagEvaluationDetails(typing.Generic[T]):
     reason: typing.Optional[Reason] = None
     error_code: typing.Optional[ErrorCode] = None
     error_message: typing.Optional[str] = None
-
-    @property
-    def reason(self) -> str:
-        return self._reason.value
-
-    @reason.setter
-    def reason(self, reason: Reason):
-        self._reason = reason

--- a/open_feature/flag_evaluation/reason.py
+++ b/open_feature/flag_evaluation/reason.py
@@ -1,7 +1,7 @@
-from enum import Enum
+from open_feature._backports.strenum import StrEnum
 
 
-class Reason(Enum):
+class Reason(StrEnum):
     CACHED = "CACHED"
     DEFAULT = "DEFAULT"
     DISABLED = "DISABLED"

--- a/tests/test_open_feature_client.py
+++ b/tests/test_open_feature_client.py
@@ -95,7 +95,7 @@ def test_should_raise_exception_when_invalid_flag_type_provided(no_op_provider_c
     assert flag.value
     assert flag.error_message == "Unknown flag type"
     assert flag.error_code == ErrorCode.GENERAL
-    assert flag.reason == Reason.ERROR.value
+    assert flag.reason == Reason.ERROR
 
 
 def test_should_handle_a_generic_exception_thrown_by_a_provider(no_op_provider_client):
@@ -111,7 +111,7 @@ def test_should_handle_a_generic_exception_thrown_by_a_provider(no_op_provider_c
     assert flag_details is not None
     assert flag_details.value
     assert isinstance(flag_details.value, bool)
-    assert flag_details.reason == Reason.ERROR.value
+    assert flag_details.reason == Reason.ERROR
     assert flag_details.error_message == "Generic exception raised"
 
 
@@ -133,7 +133,7 @@ def test_should_handle_an_open_feature_exception_thrown_by_a_provider(
     assert flag_details is not None
     assert flag_details.value
     assert isinstance(flag_details.value, bool)
-    assert flag_details.reason == Reason.ERROR.value
+    assert flag_details.reason == Reason.ERROR
     assert flag_details.error_message == "error_message"
 
 

--- a/tests/test_open_feature_flag_evaluation.py
+++ b/tests/test_open_feature_flag_evaluation.py
@@ -28,7 +28,7 @@ def test_evaulation_details_reason_should_be_a_string():
     assert variant == flag_details.variant
     assert error_code == flag_details.error_code
     assert error_message == flag_details.error_message
-    assert reason.value == flag_details.reason
+    assert reason == flag_details.reason
 
 
 def test_evaulation_details_reason_should_be_a_string_when_set():
@@ -52,4 +52,4 @@ def test_evaulation_details_reason_should_be_a_string_when_set():
     flag_details.reason = Reason.STATIC
 
     # Then
-    assert Reason.STATIC.value == flag_details.reason
+    assert Reason.STATIC == flag_details.reason


### PR DESCRIPTION
## This PR

Is a refinement on #126. In particular, it makes Reason values also instances of str, and thus directly comparable without having to access the `.value` property, and without having to define custom getters and setters in dataclasses.

The motivation for this was to fix a `no-redef` issue reported by mypy in the FlagEvaluationDetails definition:

```
open_feature/flag_evaluation/flag_evaluation_details.py:19: error: Name "reason" already defined on line 15  [no-redef]
```

`StrEnum` is available since Python 3.11 so it requires a minimal backport for earlier Python versions.
