### PR TITLE
fix: add PEP 561 py.typed marker file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,3 +28,6 @@ Homepage = "https://github.com/open-feature/python-sdk"
 [tool.isort]
 profile = "black"
 multi_line_output = 3
+
+[tool.setuptools.package-data]
+openfeature = ["py.typed"]


### PR DESCRIPTION
## This PR

Adds a py.typed marker file to the `openfeature` package to indicate that the package supports typing, following [PEP 561](https://peps.python.org/pep-0561/#packaging-type-information).
