### PR TITLE
fix: fix types for HookContext.{client,provider}_metadata

### DIFF
--- a/openfeature/hook/__init__.py
+++ b/openfeature/hook/__init__.py
@@ -3,9 +3,14 @@ from __future__ import annotations
 import typing
 from dataclasses import dataclass
 from enum import Enum
+from typing import TYPE_CHECKING
 
 from openfeature.evaluation_context import EvaluationContext
 from openfeature.flag_evaluation import FlagEvaluationDetails, FlagType
+
+if TYPE_CHECKING:
+    from openfeature.client import ClientMetadata
+    from openfeature.provider.metadata import Metadata
 
 
 class HookType(Enum):
@@ -21,8 +26,8 @@ class HookContext:
     flag_type: FlagType
     default_value: typing.Any
     evaluation_context: EvaluationContext
-    client_metadata: typing.Optional[dict] = None
-    provider_metadata: typing.Optional[dict] = None
+    client_metadata: typing.Optional["ClientMetadata"] = None
+    provider_metadata: typing.Optional["Metadata"] = None
 
 
 class Hook:


### PR DESCRIPTION
## This PR

Corrects type information for some HookContext fields. Yup, it's ugly to prevent a circular import problem, there might be a better way to do it but I haven't found it.
