### PR TITLE
chore: replace black, flake8 and isort with ruff and ruff-format

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,0 @@
-[flake8]
-max-line-length = 88
-exclude = .venv/*,venv/*,.git,__pycache__

--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -1,0 +1,4 @@
+name: "CodeQL config"
+
+paths-ignore:
+  - tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -64,18 +67,13 @@ jobs:
         uses: github/codeql-action/init@v3
         with:
           languages: python
+          config-file: ./.github/codeql-config.yml
 
       - name: Install dependencies
         run: pip install -r requirements.txt
 
-      - name: Run black formatter check
-        run: black --check .
-
-      - name: Run flake8 formatter check
-        run: flake8 .
-
-      - name: Run isort formatter check
-        run: isort .
+      - name: Run pre-commit
+        run: pre-commit/action@v3
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -12,6 +12,9 @@ on:
       - edited
       - synchronize
 
+permissions:
+  pull-requests: read
+
 jobs:
   main:
     name: Validate PR title

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,28 +1,15 @@
 default_stages: [commit]
 repos:
-  - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.9
     hooks:
-      - id: isort
-        args: ["--profile", "black", "--filter-files"]
-
-  - repo: https://github.com/psf/black
-    rev: 23.9.1
-    hooks:
-      - id: black
-        language_version: python3.9
+      - id: ruff
+        args: [ --fix ]
+      - id: ruff-format
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.5.0
     hooks:
+      - id: check-toml
       - id: check-yaml
-      - id: trailing-whitespace
       - id: check-merge-conflict
-      - id: debug-statements
-
-  - repo: https://github.com/pycqa/flake8
-    rev: 6.1.0
-    hooks:
-      - id: flake8
-        additional_dependencies:
-          ["flake8-print", "flake8-builtins", "flake8-functions==0.0.4"]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Python 3.8 and above are supported by the SDK.
 
 ### Installation and Dependencies
 
-A [`Makefile`](./Makefile) has been included in the project which should make it straightforward to start the project locally. We utilize virtual environments (see [`venv`](https://docs.python.org/3/tutorial/venv.html)) in order to provide isolated development environments for the project. This reduces the risk of invalid or corrupt global packages. It also integrates nicely with Make, which will detect changes in the `requirements-dev.txt` file and update the virtual environment if any occur.
+A [`Makefile`](./Makefile) has been included in the project which should make it straightforward to start the project locally. We utilize virtual environments (see [`venv`](https://docs.python.org/3/tutorial/venv.html)) in order to provide isolated development environments for the project. This reduces the risk of invalid or corrupt global packages. It also integrates nicely with Make, which will detect changes in the `requirements.txt` file and update the virtual environment if any occur.
 
 Run `make init` to initialize the project's virtual environment and install all dev dependencies.
 

--- a/Makefile
+++ b/Makefile
@@ -33,13 +33,11 @@ test-harness:
 
 .PHONY: lint
 lint: venv
-	$(VENV_ACTIVATE); flake8 .
-	$(VENV_ACTIVATE); isort .
-	$(VENV_ACTIVATE); black --check .
+	$(VENV_ACTIVATE); pre-commit run -a
 
 .PHONY: format
 format: venv
-	$(VENV_ACTIVATE); black .
+	$(VENV_ACTIVATE); pre-commit run -a ruff-format
 
 .PHONY: e2e
 e2e: venv test-harness

--- a/openfeature/client.py
+++ b/openfeature/client.py
@@ -314,7 +314,7 @@ class OpenFeatureClient:
             )
         # Catch any type of exception here since the user can provide any exception
         # in the error hooks
-        except Exception as err:  # noqa
+        except Exception as err:  # pragma: no cover
             error_hooks(flag_type, hook_context, err, reversed_merged_hooks, hook_hints)
 
             error_message = getattr(err, "error_message", str(err))

--- a/openfeature/flag_evaluation.py
+++ b/openfeature/flag_evaluation.py
@@ -31,13 +31,13 @@ class Reason(StrEnum):
 
 FlagMetadata = typing.Mapping[str, typing.Any]
 
-T = typing.TypeVar("T", covariant=True)
+T_co = typing.TypeVar("T_co", covariant=True)
 
 
 @dataclass
-class FlagEvaluationDetails(typing.Generic[T]):
+class FlagEvaluationDetails(typing.Generic[T_co]):
     flag_key: str
-    value: T
+    value: T_co
     variant: typing.Optional[str] = None
     flag_metadata: FlagMetadata = field(default_factory=dict)
     reason: typing.Optional[Reason] = None
@@ -51,12 +51,12 @@ class FlagEvaluationOptions:
     hook_hints: dict = field(default_factory=dict)
 
 
-U = typing.TypeVar("U", covariant=True)
+U_co = typing.TypeVar("U_co", covariant=True)
 
 
 @dataclass
-class FlagResolutionDetails(typing.Generic[U]):
-    value: U
+class FlagResolutionDetails(typing.Generic[U_co]):
+    value: U_co
     error_code: typing.Optional[ErrorCode] = None
     error_message: typing.Optional[str] = None
     reason: typing.Optional[Reason] = None

--- a/openfeature/hook/__init__.py
+++ b/openfeature/hook/__init__.py
@@ -26,8 +26,8 @@ class HookContext:
     flag_type: FlagType
     default_value: typing.Any
     evaluation_context: EvaluationContext
-    client_metadata: typing.Optional["ClientMetadata"] = None
-    provider_metadata: typing.Optional["Metadata"] = None
+    client_metadata: typing.Optional[ClientMetadata] = None
+    provider_metadata: typing.Optional[Metadata] = None
 
 
 class Hook:

--- a/openfeature/hook/hook_support.py
+++ b/openfeature/hook/hook_support.py
@@ -116,5 +116,5 @@ def _execute_hook_checked(hook: Hook, hook_method: HookType, **kwargs):
     """
     try:
         return getattr(hook, hook_method.value)(**kwargs)
-    except Exception:  # noqa
+    except Exception:  # pragma: no cover
         logging.error(f"Exception when running {hook_method.value} hooks")

--- a/openfeature/provider/in_memory_provider.py
+++ b/openfeature/provider/in_memory_provider.py
@@ -17,26 +17,28 @@ class InMemoryMetadata(Metadata):
     name: str = "In-Memory Provider"
 
 
-T = typing.TypeVar("T", covariant=True)
+T_co = typing.TypeVar("T_co", covariant=True)
 
 
 @dataclass(frozen=True)
-class InMemoryFlag(typing.Generic[T]):
+class InMemoryFlag(typing.Generic[T_co]):
     class State(StrEnum):
         ENABLED = "ENABLED"
         DISABLED = "DISABLED"
 
     default_variant: str
-    variants: typing.Dict[str, T]
+    variants: typing.Dict[str, T_co]
     flag_metadata: FlagMetadata = field(default_factory=dict)
     state: State = State.ENABLED
     context_evaluator: typing.Optional[
-        typing.Callable[["InMemoryFlag", EvaluationContext], FlagResolutionDetails[T]]
+        typing.Callable[
+            ["InMemoryFlag", EvaluationContext], FlagResolutionDetails[T_co]
+        ]
     ] = None
 
     def resolve(
         self, evaluation_context: typing.Optional[EvaluationContext]
-    ) -> FlagResolutionDetails[T]:
+    ) -> FlagResolutionDetails[T_co]:
         if self.context_evaluator:
             return self.context_evaluator(
                 self, evaluation_context or EvaluationContext()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,14 +20,62 @@ dependencies = []
 requires-python = ">=3.8"
 
 [project.optional-dependencies]
-dev = ["black", "flake8", "isort", "pip-tools", "pytest", "pre-commit"]
+dev = ["pip-tools", "pytest", "pre-commit"]
 
 [project.urls]
 Homepage = "https://github.com/open-feature/python-sdk"
 
-[tool.isort]
-profile = "black"
-multi_line_output = 3
+[tool.ruff]
+exclude = [
+    ".git",
+    ".venv",
+    "__pycache__",
+    "venv",
+]
+target-version = "py38"
+
+[tool.ruff.lint]
+select = [
+    "A",
+    "B",
+    "C4",
+    "C90",
+    "E",
+    "F",
+    "FLY",
+    "FURB",
+    "I",
+    "LOG",
+    "N",
+    "PERF",
+    "PGH",
+    "PLC",
+    "PLR0913",
+    "PLR0915",
+    "RUF",
+    "S",
+    "SIM",
+    "T10",
+    "T20",
+    "UP",
+    "W",
+    "YTT",
+]
+ignore = [
+    "E501" # the formatter will handle any too long line
+]
+preview = true
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*" = ["PLR0913", "S101"]
+
+[tool.ruff.lint.pylint]
+max-args = 6
+max-statements = 30
+
+[tool.ruff.lint.pyupgrade]
+# Preserve types, even if a file imports `from __future__ import annotations`.
+keep-runtime-typing = true
 
 [tool.setuptools.package-data]
 openfeature = ["py.typed"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,5 @@
-pylint==3.0.3
 pytest==7.4.3
 pytest-mock==3.12.0
-black==23.12.1
 pre-commit
-flake8==6.1.0
 coverage==7.3.4
 behave==1.2.6

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ def clear_provider():
     in other tests.
     """
     yield
-    _provider = None  # noqa: F841
+    _provider = None
 
 
 @pytest.fixture()

--- a/tests/hook/test_hook_support.py
+++ b/tests/hook/test_hook_support.py
@@ -15,7 +15,7 @@ from openfeature.immutable_dict.mapping_proxy_type import MappingProxyType
 def test_error_hooks_run_error_method(mock_hook):
     # Given
     hook_context = HookContext("flag_key", FlagType.BOOLEAN, True, "")
-    hook_hints = MappingProxyType(dict())
+    hook_hints = MappingProxyType({})
     # When
     error_hooks(FlagType.BOOLEAN, hook_context, Exception, [mock_hook], hook_hints)
     # Then
@@ -29,7 +29,7 @@ def test_error_hooks_run_error_method(mock_hook):
 def test_before_hooks_run_before_method(mock_hook):
     # Given
     hook_context = HookContext("flag_key", FlagType.BOOLEAN, True, "")
-    hook_hints = MappingProxyType(dict())
+    hook_hints = MappingProxyType({})
     # When
     before_hooks(FlagType.BOOLEAN, hook_context, [mock_hook], hook_hints)
     # Then
@@ -61,7 +61,7 @@ def test_after_hooks_run_after_method(mock_hook):
     flag_evaluation_details = FlagEvaluationDetails(
         hook_context.flag_key, "val", "unknown"
     )
-    hook_hints = MappingProxyType(dict())
+    hook_hints = MappingProxyType({})
     # When
     after_hooks(
         FlagType.BOOLEAN, hook_context, flag_evaluation_details, [mock_hook], hook_hints
@@ -77,7 +77,7 @@ def test_after_hooks_run_after_method(mock_hook):
 def test_finally_after_hooks_run_finally_after_method(mock_hook):
     # Given
     hook_context = HookContext("flag_key", FlagType.BOOLEAN, True, "")
-    hook_hints = MappingProxyType(dict())
+    hook_hints = MappingProxyType({})
     # When
     after_all_hooks(FlagType.BOOLEAN, hook_context, [mock_hook], hook_hints)
     # Then

--- a/tests/provider/test_in_memory_provider.py
+++ b/tests/provider/test_in_memory_provider.py
@@ -1,5 +1,6 @@
-import pytest
 from numbers import Number
+
+import pytest
 
 from openfeature.exception import FlagNotFoundError
 from openfeature.flag_evaluation import FlagResolutionDetails, Reason

--- a/tests/test_flag_evaluation.py
+++ b/tests/test_flag_evaluation.py
@@ -53,4 +53,4 @@ def test_evaluation_details_reason_should_be_a_string_when_set():
     flag_details.reason = Reason.STATIC
 
     # Then
-    assert Reason.STATIC == flag_details.reason
+    assert Reason.STATIC == flag_details.reason  # noqa: SIM300


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- replace `black`, `flake8` and `isort` with `ruff` and `ruff-format`
- enabled the rules, which replace `flake8` and the plugins you mentioned in the `pre-commit` config
- addiontally enabled some more, which I used in an other project, but feel free to enable more, if something peaks your interest 🙂 
- fixed some minor issues, which popped up after enabling the `ruff` rules
- adjusted GHA to use the `pre-commit` action insted
- excluded the `tests` folder from CodeQL scans
- added missing `permissions` block in the GHA workflow files to properly limit the actual permissions

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #219

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

