### PR TITLE
chore: replace black, fake8 and isort with ruff and ruff-format

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,0 @@
-[flake8]
-max-line-length = 88
-exclude = .venv/*,venv/*,.git,__pycache__

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
         run: pip install -r requirements.txt
 
       - name: Run pre-commit
-        uses: pre-commit/action@v3
+        uses: pre-commit/action@v3.0.0
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
         run: pip install -r requirements.txt
 
       - name: Run pre-commit
-        run: pre-commit/action@v3
+        uses: pre-commit/action@v3
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,14 +68,8 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
 
-      - name: Run black formatter check
-        run: black --check .
-
-      - name: Run flake8 formatter check
-        run: flake8 .
-
-      - name: Run isort formatter check
-        run: isort .
+      - name: Run pre-commit
+        run: pre-commit/action@v3
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,28 +1,16 @@
 default_stages: [commit]
 repos:
-  - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.9
     hooks:
-      - id: isort
-        args: ["--profile", "black", "--filter-files"]
-
-  - repo: https://github.com/psf/black
-    rev: 23.9.1
-    hooks:
-      - id: black
-        language_version: python3.9
+      - id: ruff
+#        args: [ --fix ]
+      - id: ruff-format
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.5.0
     hooks:
+      - id: check-toml
       - id: check-yaml
       - id: trailing-whitespace
       - id: check-merge-conflict
-      - id: debug-statements
-
-  - repo: https://github.com/pycqa/flake8
-    rev: 6.1.0
-    hooks:
-      - id: flake8
-        additional_dependencies:
-          ["flake8-print", "flake8-builtins", "flake8-functions==0.0.4"]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Python 3.8 and above are supported by the SDK.
 
 ### Installation and Dependencies
 
-A [`Makefile`](./Makefile) has been included in the project which should make it straightforward to start the project locally. We utilize virtual environments (see [`venv`](https://docs.python.org/3/tutorial/venv.html)) in order to provide isolated development environments for the project. This reduces the risk of invalid or corrupt global packages. It also integrates nicely with Make, which will detect changes in the `requirements-dev.txt` file and update the virtual environment if any occur.
+A [`Makefile`](./Makefile) has been included in the project which should make it straightforward to start the project locally. We utilize virtual environments (see [`venv`](https://docs.python.org/3/tutorial/venv.html)) in order to provide isolated development environments for the project. This reduces the risk of invalid or corrupt global packages. It also integrates nicely with Make, which will detect changes in the `requirements.txt` file and update the virtual environment if any occur.
 
 Run `make init` to initialize the project's virtual environment and install all dev dependencies.
 

--- a/Makefile
+++ b/Makefile
@@ -33,13 +33,11 @@ test-harness:
 
 .PHONY: lint
 lint: venv
-	$(VENV_ACTIVATE); flake8 .
-	$(VENV_ACTIVATE); isort .
-	$(VENV_ACTIVATE); black --check .
+	$(VENV_ACTIVATE); pre-commit run -a
 
 .PHONY: format
 format: venv
-	$(VENV_ACTIVATE); black .
+	$(VENV_ACTIVATE); pre-commit run -a ruff-format
 
 .PHONY: e2e
 e2e: venv test-harness

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,14 +20,70 @@ dependencies = []
 requires-python = ">=3.8"
 
 [project.optional-dependencies]
-dev = ["black", "flake8", "isort", "pip-tools", "pytest", "pre-commit"]
+dev = ["pip-tools", "pytest", "pre-commit"]
 
 [project.urls]
 Homepage = "https://github.com/open-feature/python-sdk"
 
-[tool.isort]
-profile = "black"
-multi_line_output = 3
+[tool.ruff]
+exclude = [
+    ".git",
+    ".venv",
+    "__pycache__",
+    "venv",
+]
+target-version = "py38"
+
+[tool.ruff.lint]
+select = [
+    "A",
+    "B",
+    "C4",
+    "C90",
+    "E",
+    "F",
+    "FLY",
+    "FURB",
+    "I",
+    "LOG",
+    "N",
+    "PERF",
+    "PGH",
+    "PLC",
+    "PLR0913",
+    "PLR0915",
+    "RUF",
+    "S",
+    "SIM",
+    "T10",
+    "T20",
+    "UP",
+    "W",
+    "YTT",
+]
+ignore = [
+    "E501", # the formatter will handle any too long line
+    # all following rules will be removed in the next PR
+    "PGH004",
+    "RUF100",
+    "PLC0105",
+    "UP037",
+    "C408",
+    "I001",
+    "SIM300",
+]
+preview = true
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*" = ["PLR0913", "S101"]
+
+[tool.ruff.lint.pylint]
+max-args = 6
+max-statements = 30
+
+[tool.ruff.lint.pyupgrade]
+# Preserve types, even if a file imports `from __future__ import annotations`.
+keep-runtime-typing = true
 
 [tool.setuptools.package-data]
 openfeature = ["py.typed"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,5 @@
-pylint==3.0.3
 pytest==7.4.3
 pytest-mock==3.12.0
-black==23.12.1
 pre-commit
-flake8==6.1.0
 coverage==7.4.0
 behave==1.2.6


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- replace `black`, `flake8` and `isort` with `ruff` and `ruff-format`
- enabled the rules, which replace `flake8` and the plugins you mentioned in the `pre-commit` config
- additionally enabled some more, which I used in an other project, but feel free to enable more, if something peaks your interest 🙂 
- adjusted GHA to use the `pre-commit` action instead

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #219

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

