### PR TITLE
ci: ignore tests in CodeQL scan and add missing permission restrictions

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -1,0 +1,4 @@
+name: "CodeQL config"
+
+paths-ignore:
+  - tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -64,6 +67,7 @@ jobs:
         uses: github/codeql-action/init@v3
         with:
           languages: python
+          config-file: ./.github/codeql-config.yml
 
       - name: Install dependencies
         run: pip install -r requirements.txt

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -12,6 +12,9 @@ on:
       - edited
       - synchronize
 
+permissions:
+  pull-requests: read
+
 jobs:
   main:
     name: Validate PR title


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- excludes the `tests` from being scanned by CodeQL, which is not needed and improves scanning time
  - from ~1:35 to now ~1:18 a small improvement, which will pay off over time with more tests added 🙂 
- added missing permissions restrictions for the GHA workflow files