### PR TITLE
ci: add mypy type checking and fix/exclude minor issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,3 +14,9 @@ repos:
       - id: check-yaml
       - id: trailing-whitespace
       - id: check-merge-conflict
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.8.0
+    hooks:
+      - id: mypy
+        files: openfeature

--- a/openfeature/_backports/strenum.py
+++ b/openfeature/_backports/strenum.py
@@ -1,6 +1,8 @@
-try:
+import sys
+
+if sys.version_info >= (3, 11):
     from enum import StrEnum
-except ImportError:
+else:
     from enum import Enum
 
     class StrEnum(str, Enum):

--- a/openfeature/immutable_dict/mapping_proxy_type.py
+++ b/openfeature/immutable_dict/mapping_proxy_type.py
@@ -1,3 +1,6 @@
+import typing
+
+
 class MappingProxyType(dict):
     """
     MappingProxyType is an immutable dictionary type, written to
@@ -14,16 +17,16 @@ class MappingProxyType(dict):
     `from types import MappingProxyType`
     """
 
-    def __hash__(self):
+    def __hash__(self) -> int:  # type:ignore[override]
         return id(self)
 
-    def _immutable(self, *args, **kws):
+    def _immutable(self, *args: typing.Any, **kws: typing.Any) -> typing.NoReturn:
         raise TypeError("immutable instance of dictionary")
 
     __setitem__ = _immutable
     __delitem__ = _immutable
     clear = _immutable
-    update = _immutable
-    setdefault = _immutable
-    pop = _immutable
+    update = _immutable  # type:ignore[assignment]
+    setdefault = _immutable  # type:ignore[assignment]
+    pop = _immutable  # type:ignore[assignment]
     popitem = _immutable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,8 @@ Homepage = "https://github.com/open-feature/python-sdk"
 
 [tool.mypy]
 files = "openfeature"
+namespace_packages = true
+explicit_package_bases = true
 
 [tool.ruff]
 exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ dev = ["pip-tools", "pytest", "pre-commit"]
 [project.urls]
 Homepage = "https://github.com/open-feature/python-sdk"
 
+[tool.mypy]
+files = "openfeature"
+
 [tool.ruff]
 exclude = [
     ".git",


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- most of the code has type annotation, so this adds a type checking task inside `pre-commit`, which will be triggered during CI
- had to adjust the `StrEnum` import to use the Python system info, so the type checker can properly handle it
- the ignores in `MappingProxyType` are needed, because the original type hints are different

### Follow-up Tasks

- plan is to enable more and more `mypy` checks with follow-up PRs till `strict` mode can be enabled
