### PR TITLE
ci: split lint job into lint and sast

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,17 +63,23 @@ jobs:
           python-version: "3.11"
           cache: "pip"
 
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.0
+
+  sast:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
           languages: python
           config-file: ./.github/codeql-config.yml
-
-      - name: Install dependencies
-        run: pip install -r requirements.txt
-
-      - name: Run pre-commit
-        uses: pre-commit/action@v3.0.0
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- typically CodeQL scanning takes longer than other steps, therefore it is better to have a dedicated job for it
- also removed the `Install dependencies` step, because there are no dependencies needed for scanning the project (this could change in the future and then it would make sense to split into 2 different `requirements.txt` files or use something like `poetry` to handle dev and runtime dependencies)
