### PR TITLE
chore: enable mypy strict mode

### DIFF
--- a/openfeature/_backports/strenum.py
+++ b/openfeature/_backports/strenum.py
@@ -1,7 +1,8 @@
 import sys
 
 if sys.version_info >= (3, 11):
-    from enum import StrEnum
+    # re-export needed for type checking
+    from enum import StrEnum as StrEnum
 else:
     from enum import Enum
 

--- a/openfeature/_backports/strenum.py
+++ b/openfeature/_backports/strenum.py
@@ -2,7 +2,7 @@ import sys
 
 if sys.version_info >= (3, 11):
     # re-export needed for type checking
-    from enum import StrEnum as StrEnum
+    from enum import StrEnum as StrEnum  # noqa: PLC0414
 else:
     from enum import Enum
 

--- a/openfeature/api.py
+++ b/openfeature/api.py
@@ -21,7 +21,7 @@ def get_client(
     return OpenFeatureClient(name=name, version=version, provider=_provider)
 
 
-def set_provider(provider: AbstractProvider):
+def set_provider(provider: AbstractProvider) -> None:
     global _provider
     if provider is None:
         raise GeneralError(error_message="No provider")
@@ -46,19 +46,19 @@ def get_evaluation_context() -> EvaluationContext:
     return _evaluation_context
 
 
-def set_evaluation_context(evaluation_context: EvaluationContext):
+def set_evaluation_context(evaluation_context: EvaluationContext) -> None:
     global _evaluation_context
     if evaluation_context is None:
         raise GeneralError(error_message="No api level evaluation context")
     _evaluation_context = evaluation_context
 
 
-def add_hooks(hooks: typing.List[Hook]):
+def add_hooks(hooks: typing.List[Hook]) -> None:
     global _hooks
     _hooks = _hooks + hooks
 
 
-def clear_hooks():
+def clear_hooks() -> None:
     global _hooks
     _hooks = []
 
@@ -68,5 +68,5 @@ def get_hooks() -> typing.List[Hook]:
     return _hooks
 
 
-def shutdown():
+def shutdown() -> None:
     _provider.shutdown()

--- a/openfeature/client.py
+++ b/openfeature/client.py
@@ -45,11 +45,21 @@ GetDetailCallable = typing.Union[
         FlagResolutionDetails[typing.Union[dict, list]],
     ],
 ]
+TypeMap = typing.Dict[
+    FlagType,
+    typing.Union[
+        typing.Type[bool],
+        typing.Type[int],
+        typing.Type[float],
+        typing.Type[str],
+        typing.Tuple[typing.Type[dict], typing.Type[list]],
+    ],
+]
 
 
 @dataclass
 class ClientMetadata:
-    name: str
+    name: typing.Optional[str]
 
 
 class OpenFeatureClient:
@@ -60,17 +70,17 @@ class OpenFeatureClient:
         provider: AbstractProvider,
         context: typing.Optional[EvaluationContext] = None,
         hooks: typing.Optional[typing.List[Hook]] = None,
-    ):
+    ) -> None:
         self.name = name
         self.version = version
         self.context = context or EvaluationContext()
         self.hooks = hooks or []
         self.provider = provider
 
-    def get_metadata(self):
+    def get_metadata(self) -> ClientMetadata:
         return ClientMetadata(name=self.name)
 
-    def add_hooks(self, hooks: typing.List[Hook]):
+    def add_hooks(self, hooks: typing.List[Hook]) -> None:
         self.hooks = self.hooks + hooks
 
     def get_boolean_value(
@@ -93,7 +103,7 @@ class OpenFeatureClient:
         default_value: bool,
         evaluation_context: typing.Optional[EvaluationContext] = None,
         flag_evaluation_options: typing.Optional[FlagEvaluationOptions] = None,
-    ) -> FlagEvaluationDetails:
+    ) -> FlagEvaluationDetails[bool]:
         return self.evaluate_flag_details(
             FlagType.BOOLEAN,
             flag_key,
@@ -122,7 +132,7 @@ class OpenFeatureClient:
         default_value: str,
         evaluation_context: typing.Optional[EvaluationContext] = None,
         flag_evaluation_options: typing.Optional[FlagEvaluationOptions] = None,
-    ) -> FlagEvaluationDetails:
+    ) -> FlagEvaluationDetails[str]:
         return self.evaluate_flag_details(
             FlagType.STRING,
             flag_key,
@@ -151,7 +161,7 @@ class OpenFeatureClient:
         default_value: int,
         evaluation_context: typing.Optional[EvaluationContext] = None,
         flag_evaluation_options: typing.Optional[FlagEvaluationOptions] = None,
-    ) -> FlagEvaluationDetails:
+    ) -> FlagEvaluationDetails[int]:
         return self.evaluate_flag_details(
             FlagType.INTEGER,
             flag_key,
@@ -180,7 +190,7 @@ class OpenFeatureClient:
         default_value: float,
         evaluation_context: typing.Optional[EvaluationContext] = None,
         flag_evaluation_options: typing.Optional[FlagEvaluationOptions] = None,
-    ) -> FlagEvaluationDetails:
+    ) -> FlagEvaluationDetails[float]:
         return self.evaluate_flag_details(
             FlagType.FLOAT,
             flag_key,
@@ -195,7 +205,7 @@ class OpenFeatureClient:
         default_value: typing.Union[dict, list],
         evaluation_context: typing.Optional[EvaluationContext] = None,
         flag_evaluation_options: typing.Optional[FlagEvaluationOptions] = None,
-    ) -> dict:
+    ) -> typing.Union[dict, list]:
         return self.get_object_details(
             flag_key,
             default_value,
@@ -209,7 +219,7 @@ class OpenFeatureClient:
         default_value: typing.Union[dict, list],
         evaluation_context: typing.Optional[EvaluationContext] = None,
         flag_evaluation_options: typing.Optional[FlagEvaluationOptions] = None,
-    ) -> FlagEvaluationDetails:
+    ) -> FlagEvaluationDetails[typing.Union[dict, list]]:
         return self.evaluate_flag_details(
             FlagType.OBJECT,
             flag_key,
@@ -225,7 +235,7 @@ class OpenFeatureClient:
         default_value: typing.Any,
         evaluation_context: typing.Optional[EvaluationContext] = None,
         flag_evaluation_options: typing.Optional[FlagEvaluationOptions] = None,
-    ) -> FlagEvaluationDetails:
+    ) -> FlagEvaluationDetails[typing.Any]:
         """
         Evaluate the flag requested by the user from the clients provider.
 
@@ -335,7 +345,7 @@ class OpenFeatureClient:
         flag_key: str,
         default_value: typing.Any,
         evaluation_context: typing.Optional[EvaluationContext] = None,
-    ) -> FlagEvaluationDetails:
+    ) -> FlagEvaluationDetails[typing.Any]:
         """
         Encapsulated method to create a FlagEvaluationDetail from a specific provider.
 
@@ -384,8 +394,8 @@ class OpenFeatureClient:
         )
 
 
-def _typecheck_flag_value(value, flag_type):
-    type_map = {
+def _typecheck_flag_value(value: typing.Any, flag_type: FlagType) -> None:
+    type_map: TypeMap = {
         FlagType.BOOLEAN: bool,
         FlagType.STRING: str,
         FlagType.OBJECT: (dict, list),

--- a/openfeature/hook/__init__.py
+++ b/openfeature/hook/__init__.py
@@ -46,8 +46,11 @@ class Hook:
         return None
 
     def after(
-        self, hook_context: HookContext, details: FlagEvaluationDetails, hints: dict
-    ):
+        self,
+        hook_context: HookContext,
+        details: FlagEvaluationDetails[typing.Any],
+        hints: dict,
+    ) -> None:
         """
         Runs after a flag is resolved.
 
@@ -58,7 +61,9 @@ class Hook:
         """
         pass
 
-    def error(self, hook_context: HookContext, exception: Exception, hints: dict):
+    def error(
+        self, hook_context: HookContext, exception: Exception, hints: dict
+    ) -> None:
         """
         Run when evaluation encounters an error. Errors thrown will be swallowed.
 
@@ -68,7 +73,7 @@ class Hook:
         """
         pass
 
-    def finally_after(self, hook_context: HookContext, hints: dict):
+    def finally_after(self, hook_context: HookContext, hints: dict) -> None:
         """
         Run after flag evaluation, including any error processing.
         This will always run. Errors will be swallowed.

--- a/openfeature/provider/in_memory_provider.py
+++ b/openfeature/provider/in_memory_provider.py
@@ -32,7 +32,7 @@ class InMemoryFlag(typing.Generic[T_co]):
     state: State = State.ENABLED
     context_evaluator: typing.Optional[
         typing.Callable[
-            ["InMemoryFlag", EvaluationContext], FlagResolutionDetails[T_co]
+            ["InMemoryFlag[T_co]", EvaluationContext], FlagResolutionDetails[T_co]
         ]
     ] = None
 
@@ -52,7 +52,7 @@ class InMemoryFlag(typing.Generic[T_co]):
         )
 
 
-FlagStorage = typing.Dict[str, InMemoryFlag]
+FlagStorage = typing.Dict[str, InMemoryFlag[typing.Any]]
 
 V = typing.TypeVar("V")
 
@@ -60,7 +60,7 @@ V = typing.TypeVar("V")
 class InMemoryProvider(AbstractProvider):
     _flags: FlagStorage
 
-    def __init__(self, flags: FlagStorage):
+    def __init__(self, flags: FlagStorage) -> None:
         self._flags = flags.copy()
 
     def get_metadata(self) -> Metadata:

--- a/openfeature/provider/provider.py
+++ b/openfeature/provider/provider.py
@@ -8,10 +8,10 @@ from openfeature.provider.metadata import Metadata
 
 
 class AbstractProvider:
-    def initialize(self, evaluation_context: EvaluationContext):
+    def initialize(self, evaluation_context: EvaluationContext) -> None:
         pass
 
-    def shutdown(self):
+    def shutdown(self) -> None:
         pass
 
     @abstractmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ Homepage = "https://github.com/open-feature/python-sdk"
 files = "openfeature"
 namespace_packages = true
 explicit_package_bases = true
+pretty = true
+strict = true
+disallow_any_generics = false
 
 [tool.ruff]
 exclude = [


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- most of the type hint changes are pretty straight forward
- one check of the `strict` checks is disabled to keep this PR rather small
- changed a list-filter-lambda combo to a list comprehension, because `mypy` tripped on it and in general list comprehension are more performant compared to such a combo
- also enabled `mypy` pretty mode, which gives quite nice error outputs
ex. 
```python
openfeature/hook/hook_support.py:52: error: Missing type parameters for generic
type "Mapping"  [type-arg]
        hints: typing.Optional[typing.Mapping] = None,
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```
