### PR TITLE
ci: change codecov GHA version to v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
           behave tests/features/
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@c9e0f0b3cf5f112462339d69850c01735114b9ed
+        uses: codecov/codecov-action@v3
         with:
           flags: unittests # optional
           name: coverage # optional


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- I'm not sure why #226 fails the whole time, but this will remove the need to bump the version every couple of weeks

