### PR TITLE
fix: Allow string values for `FlagEvaluationDetails.reason` and  `FlagResolutionDetails.reason`

### DIFF
--- a/openfeature/flag_evaluation.py
+++ b/openfeature/flag_evaluation.py
@@ -40,7 +40,7 @@ class FlagEvaluationDetails(typing.Generic[T_co]):
     value: T_co
     variant: typing.Optional[str] = None
     flag_metadata: FlagMetadata = field(default_factory=dict)
-    reason: typing.Optional[Reason] = None
+    reason: typing.Optional[typing.Union[str, Reason]] = None
     error_code: typing.Optional[ErrorCode] = None
     error_message: typing.Optional[str] = None
 
@@ -59,6 +59,6 @@ class FlagResolutionDetails(typing.Generic[U_co]):
     value: U_co
     error_code: typing.Optional[ErrorCode] = None
     error_message: typing.Optional[str] = None
-    reason: typing.Optional[Reason] = None
+    reason: typing.Optional[typing.Union[str, Reason]] = None
     variant: typing.Optional[str] = None
     flag_metadata: FlagMetadata = field(default_factory=dict)

--- a/tests/test_flag_evaluation.py
+++ b/tests/test_flag_evaluation.py
@@ -30,6 +30,32 @@ def test_evaluation_details_reason_should_be_a_string():
     assert error_code == flag_details.error_code
     assert error_message == flag_details.error_message
     assert reason == flag_details.reason
+    assert isinstance(flag_details.reason, str)
+
+
+def test_evaluation_details_reason_can_be_arbitrary_string():
+    # Given
+    flag_key = "my-flag"
+    flag_value = 100
+    variant = "1-hundred"
+    flag_metadata = {}
+    reason = "Non-standard reason"
+    error_code = ErrorCode.GENERAL
+    error_message = "message"
+
+    # When
+    flag_details = FlagEvaluationDetails(
+        flag_key,
+        flag_value,
+        variant,
+        flag_metadata,
+        reason,
+        error_code,
+        error_message,
+    )
+
+    # Then
+    assert reason == flag_details.reason
 
 
 def test_evaluation_details_reason_should_be_a_string_when_set():
@@ -54,3 +80,4 @@ def test_evaluation_details_reason_should_be_a_string_when_set():
 
     # Then
     assert Reason.STATIC == flag_details.reason  # noqa: SIM300
+    assert isinstance(flag_details.reason, str)

--- a/tests/test_flag_evaluation.py
+++ b/tests/test_flag_evaluation.py
@@ -30,32 +30,6 @@ def test_evaluation_details_reason_should_be_a_string():
     assert error_code == flag_details.error_code
     assert error_message == flag_details.error_message
     assert reason == flag_details.reason
-    assert isinstance(flag_details.reason, str)
-
-
-def test_evaluation_details_reason_can_be_arbitrary_string():
-    # Given
-    flag_key = "my-flag"
-    flag_value = 100
-    variant = "1-hundred"
-    flag_metadata = {}
-    reason = "Non-standard reason"
-    error_code = ErrorCode.GENERAL
-    error_message = "message"
-
-    # When
-    flag_details = FlagEvaluationDetails(
-        flag_key,
-        flag_value,
-        variant,
-        flag_metadata,
-        reason,
-        error_code,
-        error_message,
-    )
-
-    # Then
-    assert reason == flag_details.reason
 
 
 def test_evaluation_details_reason_should_be_a_string_when_set():
@@ -80,4 +54,3 @@ def test_evaluation_details_reason_should_be_a_string_when_set():
 
     # Then
     assert Reason.STATIC == flag_details.reason  # noqa: SIM300
-    assert isinstance(flag_details.reason, str)


### PR DESCRIPTION
## This PR

Expands the types allowed for `reason` on `FlagEvaluationDetails` and `FlagResolutionDetails` to include both `Reason` and `str` types.

### Related Issues

Fixes #262

### Notes

Related to spec issue: https://github.com/open-feature/spec/issues/236

