### PR TITLE
feat: make return value not optional in provider API functions

### DIFF
--- a/openfeature/api.py
+++ b/openfeature/api.py
@@ -31,12 +31,12 @@ def set_provider(provider: FeatureProvider) -> None:
     provider.initialize(_evaluation_context)
 
 
-def get_provider() -> typing.Optional[FeatureProvider]:
+def get_provider() -> FeatureProvider:
     global _provider
     return _provider
 
 
-def get_provider_metadata() -> typing.Optional[Metadata]:
+def get_provider_metadata() -> Metadata:
     global _provider
     return _provider.get_metadata()
 

--- a/openfeature/client.py
+++ b/openfeature/client.py
@@ -25,7 +25,6 @@ from openfeature.hook.hook_support import (
     error_hooks,
 )
 from openfeature.provider import FeatureProvider
-from openfeature.provider.no_op_provider import NoOpProvider
 
 logger = logging.getLogger("openfeature")
 
@@ -373,10 +372,6 @@ class OpenFeatureClient:
             default_value,
             evaluation_context,
         )
-
-        if not self.provider:
-            logger.info("No provider configured, using no-op provider.")
-            self.provider = NoOpProvider()
 
         get_details_callables: typing.Mapping[FlagType, GetDetailCallable] = {
             FlagType.BOOLEAN: self.provider.resolve_boolean_details,


### PR DESCRIPTION

## This PR

Modifies the `get_provider` and `get_provider_metadata` return types to guarantee that they don't return a `None` value. 

The default provider is initialized as a NoOpProvider at module loading time, so this simplifies the usage of the provider functions for clients.