### PR TITLE
chore: update ruff version to 0.2.1 and remove preview flag

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 default_stages: [commit]
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.9
+    rev: v0.2.1
     hooks:
       - id: ruff
-#        args: [ --fix ]
+        args: [--fix]
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,6 @@ select = [
 ignore = [
     "E501", # the formatter will handle any too long line
 ]
-preview = true
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*" = ["PLR0913", "S101"]


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
 - Updates ruff version to 0.2.1 and removes deprecated preview flag. Also adds the --fix option to pre-commit hook
