### PR TITLE
refactor: remove abstractmethod decorator from get_provider_hooks

### DIFF
--- a/openfeature/provider/provider.py
+++ b/openfeature/provider/provider.py
@@ -19,7 +19,6 @@ class AbstractProvider(FeatureProvider):
     def get_metadata(self) -> Metadata:
         pass
 
-    @abstractmethod
     def get_provider_hooks(self) -> typing.List[Hook]:
         return []
 


### PR DESCRIPTION
Remove `@abstractmethod` decorator which is causing build failures in https://github.com/open-feature/python-sdk-contrib/pull/37#issuecomment-1936528976

The method already provides a default implementation.