### PR TITLE
docs: Add Missing Imports in Provider Dev Example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,10 +235,12 @@ This can be a new repository or included in [the existing contrib repository](ht
 You’ll then need to write the provider by implementing the `AbstractProvider` class exported by the OpenFeature SDK.
 
 ```python
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from openfeature.evaluation_context import EvaluationContext
 from openfeature.flag_evaluation import FlagResolutionDetails
+from openfeature.hook import Hook
+from openfeature.provider.metadata import Metadata
 from openfeature.provider.provider import AbstractProvider
 
 class MyProvider(AbstractProvider):


### PR DESCRIPTION
Just a simple doc update to add missing imports to the sample code.