### PR TITLE
docs: update spec version to 0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
 <!-- The 'github-badges' class is used in the docs -->
 <p align="center" class="github-badges">
 
-  <a href="https://github.com/open-feature/spec/releases/tag/v0.5.2">
-    <img alt="Specification" src="https://img.shields.io/static/v1?label=Specification&message=v0.5.2&color=red&style=for-the-badge" />
+  <a href="https://github.com/open-feature/spec/releases/tag/v0.8.0">
+    <img alt="Specification" src="https://img.shields.io/static/v1?label=Specification&message=v0.8.0&color=red&style=for-the-badge" />
   </a>
 
   <!-- x-release-please-start-version -->


### PR DESCRIPTION
Release-As: 0.6.0

Update spec badge to `0.8.0` as I believe this better represents the current SDK version.

We should still double-check that we aren't missing anything important but most of the 0.8.0 stuff is implemented as of today.