### PR TITLE
chore: update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,8 +4,11 @@
     "config:base"
   ],
   "semanticCommits": "enabled",
-  "pip_requirements": {
-    "fileMatch": ["requirements.txt", "requirements-dev.txt"]
+  "pep621": {
+    "enabled": true
+  },
+  "pre-commit": {
+    "enabled": true
   },
   "packageRules": [
     {


### PR DESCRIPTION
 * Replaces old `pip_requirements` manager which will not match any files with `pep621` which matches pyproject.toml
 * Configures `pre-commit` manager to update pre-commit hooks.

I'm not an expert in Renovate so not sure if this will work but it sounds reasonable.