### PR TITLE
refactor: bind providers explicitly to a registry with attach/detach

### DIFF
--- a/openfeature/provider/_registry.py
+++ b/openfeature/provider/_registry.py
@@ -71,6 +71,7 @@ class ProviderRegistry:
         return get_evaluation_context()
 
     def _initialize_provider(self, provider: FeatureProvider) -> None:
+        provider.attach(self.dispatch_event)
         try:
             if hasattr(provider, "initialize"):
                 provider.initialize(self._get_evaluation_context())
@@ -106,6 +107,7 @@ class ProviderRegistry:
                     error_code=ErrorCode.PROVIDER_FATAL,
                 ),
             )
+        provider.detach()
 
     def get_provider_status(self, provider: FeatureProvider) -> ProviderStatus:
         return self._provider_status.get(provider, ProviderStatus.NOT_READY)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -235,6 +235,8 @@ def test_clear_providers_shutdowns_every_provider_and_resets_default_provider():
 def test_provider_events():
     # Given
     spy = MagicMock()
+    provider = NoOpProvider()
+    set_provider(provider)
 
     add_handler(ProviderEvent.PROVIDER_READY, spy.provider_ready)
     add_handler(
@@ -242,8 +244,6 @@ def test_provider_events():
     )
     add_handler(ProviderEvent.PROVIDER_ERROR, spy.provider_error)
     add_handler(ProviderEvent.PROVIDER_STALE, spy.provider_stale)
-
-    provider = NoOpProvider()
 
     provider_details = ProviderEventDetails(message="message")
     details = EventDetails.from_provider_event_details(


### PR DESCRIPTION
This opens the door to handling events for child providers inside composite providers.