### PR TITLE
fix: remove exception logging during evaluation

### DIFF
--- a/openfeature/client.py
+++ b/openfeature/client.py
@@ -361,19 +361,13 @@ class OpenFeatureClient:
             return flag_evaluation
 
         except OpenFeatureError as err:
-            logger.exception(
-                "Error %s while evaluating flag with key: '%s'",
-                err.error_code,
-                flag_key,
-            )
-
             error_hooks(flag_type, hook_context, err, reversed_merged_hooks, hook_hints)
 
             return FlagEvaluationDetails(
                 flag_key=flag_key,
                 value=default_value,
                 reason=Reason.ERROR,
-                error_code=err.error_code,
+                error_code=err.error_code or ErrorCode.GENERAL,
                 error_message=err.error_message,
             )
         # Catch any type of exception here since the user can provide any exception

--- a/openfeature/client.py
+++ b/openfeature/client.py
@@ -367,7 +367,7 @@ class OpenFeatureClient:
                 flag_key=flag_key,
                 value=default_value,
                 reason=Reason.ERROR,
-                error_code=err.error_code or ErrorCode.GENERAL,
+                error_code=err.error_code,
                 error_message=err.error_message,
             )
         # Catch any type of exception here since the user can provide any exception


### PR DESCRIPTION
## This PR

- remove exception logging during evaluation

### Impacts

https://github.com/open-telemetry/opentelemetry-demo/issues/1628

### Notes

The OTel demo was seeing overly verbose log messages when they disabled a flag. That's because a `FLAG_NOT_FOUND` error was raised by the provider, and the SDK was logging all exceptions. I've updated the SDK to no longer log OpenFeatureErrors since providers commonly raise these, which can lead to log spam. It's worth noting that this information can still be accessed via a hook or evaluation details.