### PR TITLE
ci: run release please as OpenFeature bot

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{secrets.GITHUB_TOKEN}}
+          token: ${{secrets.RELEASE_PLEASE_ACTION_TOKEN}}
           target-branch: main
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "bootstrap-sha": "198336b098f167f858675235214cc907ede10182",
+  "signoff": "OpenFeature Bot <109696520+openfeaturebot@users.noreply.github.com>",
   "packages": {
     ".": {
       "release-type": "python",


### PR DESCRIPTION
## This PR

- run release please as the OpenFeature bot

### Notes

This should allow GitHub actions to run when release please opens a release PR.

