### PR TITLE
feat: implement transaction context

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ app = Flask(__name__)
 api.set_transaction_context_propagator(ContextVarsTransactionContextPropagator())
 
 # Middleware to set the transaction context
-# You can call api.set_transaction_context anywhere you have information, 
+# You can call api.set_transaction_context anywhere you have information,
 # you want to have available in the code-paths below the current one.
 @app.before_request
 def set_request_transaction_context():
@@ -269,7 +269,7 @@ def set_request_transaction_context():
   api.set_transaction_context(evaluation_context)
 
 def create_response() -> str:
-  # This method can be anywhere in our code. 
+  # This method can be anywhere in our code.
   # The feature flag evaluation will automatically contain the transaction context merged with other context
   new_response = api.get_client().get_string_value("response-message", "Hello User!")
   return f"Message from server: {new_response}"

--- a/README.md
+++ b/README.md
@@ -99,16 +99,17 @@ print("Value: " + str(flag_value))
 
 ## 🌟 Features
 
-| Status | Features                        | Description                                                                                                                        |
-| ------ | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| ✅      | [Providers](#providers)         | Integrate with a commercial, open source, or in-house feature management tool.                                                     |
-| ✅      | [Targeting](#targeting)         | Contextually-aware flag evaluation using [evaluation context](https://openfeature.dev/docs/reference/concepts/evaluation-context). |
-| ✅      | [Hooks](#hooks)                 | Add functionality to various stages of the flag evaluation life-cycle.                                                             |
-| ✅      | [Logging](#logging)             | Integrate with popular logging packages.                                                                                           |
-| ✅      | [Domains](#domains)             | Logically bind clients with providers.                                                                                             |
-| ✅      | [Eventing](#eventing)           | React to state changes in the provider or flag management system.                                                                  |
-| ✅      | [Shutdown](#shutdown)           | Gracefully clean up a provider during application shutdown.                                                                        |
-| ✅      | [Extending](#extending)         | Extend OpenFeature with custom providers and hooks.                                                                                |
+| Status | Features                                                            | Description                                                                                                                           |
+|--------|---------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
+| ✅      | [Providers](#providers)                                             | Integrate with a commercial, open source, or in-house feature management tool.                                                        |
+| ✅      | [Targeting](#targeting)                                             | Contextually-aware flag evaluation using [evaluation context](https://openfeature.dev/docs/reference/concepts/evaluation-context).    |
+| ✅      | [Hooks](#hooks)                                                     | Add functionality to various stages of the flag evaluation life-cycle.                                                                |
+| ✅      | [Logging](#logging)                                                 | Integrate with popular logging packages.                                                                                              |
+| ✅      | [Domains](#domains)                                                 | Logically bind clients with providers.                                                                                                |
+| ✅      | [Eventing](#eventing)                                               | React to state changes in the provider or flag management system.                                                                     |
+| ✅      | [Shutdown](#shutdown)                                               | Gracefully clean up a provider during application shutdown.                                                                           |
+| ✅      | [Transaction Context Propagation](#transaction-context-propagation) | Set a specific [evaluation context](/docs/reference/concepts/evaluation-context) for a transaction (e.g. an HTTP request or a thread) |
+| ✅      | [Extending](#extending)                                             | Extend OpenFeature with custom providers and hooks.                                                                                   |
 
 <sub>Implemented: ✅ | In-progress: ⚠️ | Not implemented yet: ❌</sub>
 
@@ -233,6 +234,86 @@ def on_provider_ready(event_details: EventDetails):
     print(f"Provider {event_details.provider_name} is ready")
 
 client.add_handler(ProviderEvent.PROVIDER_READY, on_provider_ready)
+```
+
+### Transaction Context Propagation
+
+Transaction context is a container for transaction-specific evaluation context (e.g. user id, user agent, IP).
+Transaction context can be set where specific data is available (e.g. an auth service or request handler) and by using the transaction context propagator it will automatically be applied to all flag evaluations within a transaction (e.g. a request or thread).
+
+You can implement a different transaction context propagator by implementing the `TransactionContextPropagator` class exported by the OpenFeature SDK.
+In most cases you can use `ContextVarsTransactionContextPropagator` as it works for `threads` and `asyncio` using [Context Variables](https://peps.python.org/pep-0567/).
+
+The following example shows a **multithreaded** Flask application using transaction context propagation to propagate the request ip and user id into request scoped transaction context.
+
+```python
+from flask import Flask, request
+from openfeature import api
+from openfeature.evaluation_context import EvaluationContext
+from openfeature.transaction_context import ContextVarsTransactionContextPropagator
+
+# Initialize the Flask app
+app = Flask(__name__)
+
+# Set the transaction context propagator
+api.set_transaction_context_propagator(ContextVarsTransactionContextPropagator())
+
+# Middleware to set the transaction context
+# You can call api.set_transaction_context anywhere you have information, 
+# you want to have available in the code-paths below the current one.
+@app.before_request
+def set_request_transaction_context():
+  ip = request.headers.get("X-Forwarded-For", request.remote_addr)
+  user_id = request.headers.get("User-Id")  # Assuming we're getting the user ID from a header
+  evaluation_context = EvaluationContext(targeting_key=user_id, attributes={"ipAddress": ip})
+  api.set_transaction_context(evaluation_context)
+
+def create_response() -> str:
+  # This method can be anywhere in our code. 
+  # The feature flag evaluation will automatically contain the transaction context merged with other context
+  new_response = api.get_client().get_string_value("response-message", "Hello User!")
+  return f"Message from server: {new_response}"
+
+# Example route where we use the transaction context
+@app.route('/greeting')
+def some_endpoint():
+  return create_response()
+```
+
+This also works for asyncio based implementations e.g. FastApi as seen in the following example:
+
+```python
+from fastapi import FastAPI, Request
+from openfeature import api
+from openfeature.evaluation_context import EvaluationContext
+from openfeature.transaction_context import ContextVarsTransactionContextPropagator
+
+# Initialize the FastAPI app
+app = FastAPI()
+
+# Set the transaction context propagator
+api.set_transaction_context_propagator(ContextVarsTransactionContextPropagator())
+
+# Middleware to set the transaction context
+@app.middleware("http")
+async def set_request_transaction_context(request: Request, call_next):
+    ip = request.headers.get("X-Forwarded-For", request.client.host)
+    user_id = request.headers.get("User-Id")  # Assuming we're getting the user ID from a header
+    evaluation_context = EvaluationContext(targeting_key=user_id, attributes={"ipAddress": ip})
+    api.set_transaction_context(evaluation_context)
+    response = await call_next(request)
+    return response
+
+def create_response() -> str:
+    # This method can be located anywhere in our code.
+    # The feature flag evaluation will automatically include the transaction context merged with other context.
+    new_response = api.get_client().get_string_value("response-message", "Hello User!")
+    return f"Message from server: {new_response}"
+
+# Example route where we use the transaction context
+@app.get('/greeting')
+async def some_endpoint():
+    return create_response()
 ```
 
 ### Shutdown

--- a/openfeature/api.py
+++ b/openfeature/api.py
@@ -12,9 +12,9 @@ from openfeature.hook import Hook
 from openfeature.provider import FeatureProvider
 from openfeature.provider._registry import provider_registry
 from openfeature.provider.metadata import Metadata
-from openfeature.transaction_context import (
+from openfeature.transaction_context import TransactionContextPropagator
+from openfeature.transaction_context.no_op_transaction_context_propagator import (
     NoOpTransactionContextPropagator,
-    TransactionContextPropagator,
 )
 
 __all__ = [

--- a/openfeature/api.py
+++ b/openfeature/api.py
@@ -12,6 +12,10 @@ from openfeature.hook import Hook
 from openfeature.provider import FeatureProvider
 from openfeature.provider._registry import provider_registry
 from openfeature.provider.metadata import Metadata
+from openfeature.transaction_context import (
+    NoOpTransactionContextPropagator,
+    TransactionContextPropagator,
+)
 
 __all__ = [
     "get_client",
@@ -20,6 +24,9 @@ __all__ = [
     "get_provider_metadata",
     "get_evaluation_context",
     "set_evaluation_context",
+    "set_transaction_context_propagator",
+    "get_transaction_context",
+    "set_transaction_context",
     "add_hooks",
     "clear_hooks",
     "get_hooks",
@@ -29,6 +36,7 @@ __all__ = [
 ]
 
 _evaluation_context = EvaluationContext()
+_evaluation_transaction_context_propagator = NoOpTransactionContextPropagator()
 
 _hooks: typing.List[Hook] = []
 
@@ -66,6 +74,24 @@ def set_evaluation_context(evaluation_context: EvaluationContext) -> None:
     if evaluation_context is None:
         raise GeneralError(error_message="No api level evaluation context")
     _evaluation_context = evaluation_context
+
+
+def set_transaction_context_propagator(
+    transaction_context_propagator: TransactionContextPropagator,
+) -> None:
+    global _evaluation_transaction_context_propagator
+    _evaluation_transaction_context_propagator = transaction_context_propagator
+
+
+def get_transaction_context() -> EvaluationContext:
+    return _evaluation_transaction_context_propagator.get_transaction_context()
+
+
+def set_transaction_context(evaluation_context: EvaluationContext) -> None:
+    global _evaluation_transaction_context_propagator
+    _evaluation_transaction_context_propagator.set_transaction_context(
+        evaluation_context
+    )
 
 
 def add_hooks(hooks: typing.List[Hook]) -> None:

--- a/openfeature/api.py
+++ b/openfeature/api.py
@@ -36,7 +36,9 @@ __all__ = [
 ]
 
 _evaluation_context = EvaluationContext()
-_evaluation_transaction_context_propagator = NoOpTransactionContextPropagator()
+_evaluation_transaction_context_propagator: TransactionContextPropagator = (
+    NoOpTransactionContextPropagator()
+)
 
 _hooks: typing.List[Hook] = []
 

--- a/openfeature/client.py
+++ b/openfeature/client.py
@@ -335,9 +335,10 @@ class OpenFeatureClient:
             )
             invocation_context = invocation_context.merge(ctx2=evaluation_context)
 
-            # Requirement 3.2.2 merge: API.context->client.context->invocation.context
+            # Requirement 3.2.2 merge: API.context->transaction.context->client.context->invocation.context
             merged_context = (
                 api.get_evaluation_context()
+                .merge(api.get_transaction_context())
                 .merge(self.context)
                 .merge(invocation_context)
             )

--- a/openfeature/transaction_context/__init__.py
+++ b/openfeature/transaction_context/__init__.py
@@ -1,0 +1,15 @@
+from openfeature.transaction_context.context_var_transaction_context_propagator import (
+    ContextVarsTransactionContextPropagator,
+)
+from openfeature.transaction_context.no_op_transaction_context_propagator import (
+    NoOpTransactionContextPropagator,
+)
+from openfeature.transaction_context.transaction_context_propagator import (
+    TransactionContextPropagator,
+)
+
+__all__ = [
+    "TransactionContextPropagator",
+    "NoOpTransactionContextPropagator",
+    "ContextVarsTransactionContextPropagator",
+]

--- a/openfeature/transaction_context/__init__.py
+++ b/openfeature/transaction_context/__init__.py
@@ -1,15 +1,11 @@
 from openfeature.transaction_context.context_var_transaction_context_propagator import (
     ContextVarsTransactionContextPropagator,
 )
-from openfeature.transaction_context.no_op_transaction_context_propagator import (
-    NoOpTransactionContextPropagator,
-)
 from openfeature.transaction_context.transaction_context_propagator import (
     TransactionContextPropagator,
 )
 
 __all__ = [
     "TransactionContextPropagator",
-    "NoOpTransactionContextPropagator",
     "ContextVarsTransactionContextPropagator",
 ]

--- a/openfeature/transaction_context/context_var_transaction_context_propagator.py
+++ b/openfeature/transaction_context/context_var_transaction_context_propagator.py
@@ -1,0 +1,18 @@
+from contextvars import ContextVar
+
+from openfeature.evaluation_context import EvaluationContext
+from openfeature.transaction_context.transaction_context_propagator import (
+    TransactionContextPropagator,
+)
+
+_transaction_context_var: ContextVar[EvaluationContext] = ContextVar(
+    "transaction_context", default=EvaluationContext()
+)
+
+
+class ContextVarsTransactionContextPropagator(TransactionContextPropagator):
+    def get_transaction_context(self) -> EvaluationContext:
+        return _transaction_context_var.get()
+
+    def set_transaction_context(self, transaction_context: EvaluationContext) -> None:
+        _transaction_context_var.set(transaction_context)

--- a/openfeature/transaction_context/context_var_transaction_context_propagator.py
+++ b/openfeature/transaction_context/context_var_transaction_context_propagator.py
@@ -5,14 +5,14 @@ from openfeature.transaction_context.transaction_context_propagator import (
     TransactionContextPropagator,
 )
 
-_transaction_context_var: ContextVar[EvaluationContext] = ContextVar(
-    "transaction_context", default=EvaluationContext()
-)
-
 
 class ContextVarsTransactionContextPropagator(TransactionContextPropagator):
+    _transaction_context_var: ContextVar[EvaluationContext] = ContextVar(
+        "transaction_context", default=EvaluationContext()
+    )
+
     def get_transaction_context(self) -> EvaluationContext:
-        return _transaction_context_var.get()
+        return self._transaction_context_var.get()
 
     def set_transaction_context(self, transaction_context: EvaluationContext) -> None:
-        _transaction_context_var.set(transaction_context)
+        self._transaction_context_var.set(transaction_context)

--- a/openfeature/transaction_context/no_op_transaction_context_propagator.py
+++ b/openfeature/transaction_context/no_op_transaction_context_propagator.py
@@ -8,5 +8,6 @@ class NoOpTransactionContextPropagator(TransactionContextPropagator):
     def get_transaction_context(self) -> EvaluationContext:
         return EvaluationContext()
 
-    def set_transaction_context(self, transaction_context: EvaluationContext) -> None:
-        pass
+    def set_transaction_context(
+        self, transaction_context: EvaluationContext
+    ) -> None: ...

--- a/openfeature/transaction_context/no_op_transaction_context_propagator.py
+++ b/openfeature/transaction_context/no_op_transaction_context_propagator.py
@@ -8,7 +8,5 @@ class NoOpTransactionContextPropagator(TransactionContextPropagator):
     def get_transaction_context(self) -> EvaluationContext:
         return EvaluationContext()
 
-    def set_transaction_context(
-        self, transaction_context: EvaluationContext
-    ) -> None:
-    pass
+    def set_transaction_context(self, transaction_context: EvaluationContext) -> None:
+        pass

--- a/openfeature/transaction_context/no_op_transaction_context_propagator.py
+++ b/openfeature/transaction_context/no_op_transaction_context_propagator.py
@@ -1,0 +1,12 @@
+from openfeature.evaluation_context import EvaluationContext
+from openfeature.transaction_context.transaction_context_propagator import (
+    TransactionContextPropagator,
+)
+
+
+class NoOpTransactionContextPropagator(TransactionContextPropagator):
+    def get_transaction_context(self) -> EvaluationContext:
+        return EvaluationContext()
+
+    def set_transaction_context(self, transaction_context: EvaluationContext) -> None:
+        pass

--- a/openfeature/transaction_context/no_op_transaction_context_propagator.py
+++ b/openfeature/transaction_context/no_op_transaction_context_propagator.py
@@ -10,4 +10,5 @@ class NoOpTransactionContextPropagator(TransactionContextPropagator):
 
     def set_transaction_context(
         self, transaction_context: EvaluationContext
-    ) -> None: ...
+    ) -> None:
+    pass

--- a/openfeature/transaction_context/transaction_context_propagator.py
+++ b/openfeature/transaction_context/transaction_context_propagator.py
@@ -1,0 +1,16 @@
+from abc import ABC, abstractmethod
+from typing import TypeVar
+
+from openfeature.evaluation_context import EvaluationContext
+
+T = TypeVar("T", bound="TransactionContextPropagator")
+
+
+class TransactionContextPropagator(ABC):
+    @abstractmethod
+    def get_transaction_context(self) -> EvaluationContext:
+        pass
+
+    @abstractmethod
+    def set_transaction_context(self, transaction_context: EvaluationContext) -> None:
+        pass

--- a/openfeature/transaction_context/transaction_context_propagator.py
+++ b/openfeature/transaction_context/transaction_context_propagator.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod
+import typing
 from typing import TypeVar
 
 from openfeature.evaluation_context import EvaluationContext
@@ -6,11 +6,9 @@ from openfeature.evaluation_context import EvaluationContext
 T = TypeVar("T", bound="TransactionContextPropagator")
 
 
-class TransactionContextPropagator(ABC):
-    @abstractmethod
-    def get_transaction_context(self) -> EvaluationContext:
-        pass
+class TransactionContextPropagator(typing.Protocol):
+    def get_transaction_context(self) -> EvaluationContext: ...
 
-    @abstractmethod
-    def set_transaction_context(self, transaction_context: EvaluationContext) -> None:
-        pass
+    def set_transaction_context(
+        self, transaction_context: EvaluationContext
+    ) -> None: ...

--- a/openfeature/transaction_context/transaction_context_propagator.py
+++ b/openfeature/transaction_context/transaction_context_propagator.py
@@ -1,9 +1,6 @@
 import typing
-from typing import TypeVar
 
 from openfeature.evaluation_context import EvaluationContext
-
-T = TypeVar("T", bound="TransactionContextPropagator")
 
 
 class TransactionContextPropagator(typing.Protocol):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "behave",
     "coverage[toml]>=6.5",
     "pytest",
+    "pytest-asyncio"
 ]
 
 [tool.hatch.envs.default.scripts]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,7 +1,7 @@
 import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock
 
 import pytest
 

--- a/tests/test_transaction_context.py
+++ b/tests/test_transaction_context.py
@@ -15,9 +15,6 @@ from openfeature.transaction_context import (
     NoOpTransactionContextPropagator,
     TransactionContextPropagator,
 )
-from openfeature.transaction_context.context_var_transaction_context_propagator import (
-    _transaction_context_var,
-)
 
 
 # Test cases
@@ -97,8 +94,12 @@ def test_should_propagate_event_when_context_set():
     set_transaction_context(evaluation_context)
 
     # Then
-    assert _transaction_context_var.get().targeting_key == "custom_key"
-    assert _transaction_context_var.get().attributes == {"attr1": "val1"}
+    assert (
+        custom_propagator._transaction_context_var.get().targeting_key == "custom_key"
+    )
+    assert custom_propagator._transaction_context_var.get().attributes == {
+        "attr1": "val1"
+    }
 
 
 def test_context_vars_transaction_context_propagator_multiple_threads():

--- a/tests/test_transaction_context.py
+++ b/tests/test_transaction_context.py
@@ -1,0 +1,172 @@
+import asyncio
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+
+from openfeature.api import (
+    get_transaction_context,
+    set_transaction_context,
+    set_transaction_context_propagator,
+)
+from openfeature.evaluation_context import EvaluationContext
+from openfeature.transaction_context import (
+    ContextVarsTransactionContextPropagator,
+    NoOpTransactionContextPropagator,
+    TransactionContextPropagator,
+)
+from openfeature.transaction_context.context_var_transaction_context_propagator import (
+    _transaction_context_var,
+)
+
+
+# Test cases
+def test_should_return_default_evaluation_context_with_noop_propagator():
+    # Given
+    set_transaction_context_propagator(NoOpTransactionContextPropagator())
+
+    # When
+    context = get_transaction_context()
+
+    # Then
+    assert isinstance(context, EvaluationContext)
+    assert context.attributes == {}
+
+
+def test_should_set_and_get_custom_transaction_context():
+    # Given
+    set_transaction_context_propagator(ContextVarsTransactionContextPropagator())
+    evaluation_context = EvaluationContext("custom_key", {"attr1": "val1"})
+
+    # When
+    set_transaction_context(evaluation_context)
+
+    # Then
+    context = get_transaction_context()
+    assert context.targeting_key == "custom_key"
+    assert context.attributes == {"attr1": "val1"}
+
+
+def test_should_override_propagator_and_reset_context():
+    # Given
+    custom_propagator = MagicMock(spec=TransactionContextPropagator)
+    default_context = EvaluationContext()
+
+    set_transaction_context_propagator(custom_propagator)
+
+    # When
+    set_transaction_context_propagator(NoOpTransactionContextPropagator())
+
+    # Then
+    assert get_transaction_context() == default_context
+
+
+def test_should_call_set_transaction_context_on_propagator():
+    # Given
+    custom_propagator = MagicMock(spec=TransactionContextPropagator)
+    evaluation_context = EvaluationContext("custom_key", {"attr1": "val1"})
+    set_transaction_context_propagator(custom_propagator)
+
+    # When
+    set_transaction_context(evaluation_context)
+
+    # Then
+    custom_propagator.set_transaction_context.assert_called_with(evaluation_context)
+
+
+def test_should_return_default_context_with_noop_propagator_set():
+    # Given
+    noop_propagator = NoOpTransactionContextPropagator()
+
+    set_transaction_context_propagator(noop_propagator)
+
+    # When
+    context = get_transaction_context()
+
+    # Then
+    assert context == EvaluationContext()
+
+
+def test_should_propagate_event_when_context_set():
+    # Given
+    custom_propagator = ContextVarsTransactionContextPropagator()
+    set_transaction_context_propagator(custom_propagator)
+    evaluation_context = EvaluationContext("custom_key", {"attr1": "val1"})
+
+    # When
+    set_transaction_context(evaluation_context)
+
+    # Then
+    assert _transaction_context_var.get().targeting_key == "custom_key"
+    assert _transaction_context_var.get().attributes == {"attr1": "val1"}
+
+
+def test_context_vars_transaction_context_propagator_multiple_threads():
+    # Given
+    context_var_propagator = ContextVarsTransactionContextPropagator()
+    set_transaction_context_propagator(context_var_propagator)
+
+    number_of_threads = 3
+    barrier = threading.Barrier(number_of_threads)
+
+    def thread_func(context_value, result_list, index):
+        context = EvaluationContext(
+            f"context_{context_value}", {"thread": context_value}
+        )
+        set_transaction_context(context)
+        barrier.wait()
+        result_list[index] = get_transaction_context()
+
+    results = [None] * number_of_threads
+    threads = []
+
+    # When
+    for i in range(3):
+        thread = threading.Thread(target=thread_func, args=(i, results, i))
+        threads.append(thread)
+        thread.start()
+
+    for thread in threads:
+        thread.join()
+
+    # Then
+    for i in range(3):
+        assert results[i].targeting_key == f"context_{i}"
+        assert results[i].attributes == {"thread": i}
+
+
+@pytest.mark.asyncio
+async def test_context_vars_transaction_context_propagator_asyncio():
+    # Given
+    context_var_propagator = ContextVarsTransactionContextPropagator()
+    set_transaction_context_propagator(context_var_propagator)
+
+    number_of_tasks = 3
+    event = asyncio.Event()
+    ready_count = 0
+
+    async def async_func(context_value, results, index):
+        nonlocal ready_count
+        context = EvaluationContext(
+            f"context_{context_value}", {"async": context_value}
+        )
+        set_transaction_context(context)
+
+        ready_count += 1  # Increment the ready count
+        if ready_count == number_of_tasks:
+            event.set()  # Set the event when all tasks are ready
+
+        await event.wait()  # Wait for the event to be set
+        results[index] = get_transaction_context()
+
+    # Placeholder for results
+    results = [None] * number_of_tasks
+
+    # When
+    tasks = [async_func(i, results, i) for i in range(number_of_tasks)]
+    await asyncio.gather(*tasks)
+
+    # Then
+    for i in range(number_of_tasks):
+        assert results[i].targeting_key == f"context_{i}"
+        assert results[i].attributes == {"async": i}

--- a/tests/test_transaction_context.py
+++ b/tests/test_transaction_context.py
@@ -12,8 +12,10 @@ from openfeature.api import (
 from openfeature.evaluation_context import EvaluationContext
 from openfeature.transaction_context import (
     ContextVarsTransactionContextPropagator,
-    NoOpTransactionContextPropagator,
     TransactionContextPropagator,
+)
+from openfeature.transaction_context.no_op_transaction_context_propagator import (
+    NoOpTransactionContextPropagator,
 )
 
 


### PR DESCRIPTION
Implements transaction context as described in #292.
This is done the same as in Node, the callback we have for Node is not needed with context vars, like it is in Java.

@federicobond just after I did the changes I saw you PR from May:
Sorry, I could have just continued test on this one. 
We basically did the same but I added some tests also for the context merging.
