### PR TITLE
fix: Finally hooks do not get called when the provider is not ready #424

### DIFF
--- a/openfeature/client.py
+++ b/openfeature/client.py
@@ -295,37 +295,39 @@ class OpenFeatureClient:
         reversed_merged_hooks = merged_hooks[:]
         reversed_merged_hooks.reverse()
 
-        status = self.get_provider_status()
-        if status == ProviderStatus.NOT_READY:
-            error_hooks(
-                flag_type,
-                hook_context,
-                ProviderNotReadyError(),
-                reversed_merged_hooks,
-                hook_hints,
-            )
-            return FlagEvaluationDetails(
-                flag_key=flag_key,
-                value=default_value,
-                reason=Reason.ERROR,
-                error_code=ErrorCode.PROVIDER_NOT_READY,
-            )
-        if status == ProviderStatus.FATAL:
-            error_hooks(
-                flag_type,
-                hook_context,
-                ProviderFatalError(),
-                reversed_merged_hooks,
-                hook_hints,
-            )
-            return FlagEvaluationDetails(
-                flag_key=flag_key,
-                value=default_value,
-                reason=Reason.ERROR,
-                error_code=ErrorCode.PROVIDER_FATAL,
-            )
-
         try:
+            status = self.get_provider_status()
+            if status == ProviderStatus.NOT_READY:
+                error_hooks(
+                    flag_type,
+                    hook_context,
+                    ProviderNotReadyError(),
+                    reversed_merged_hooks,
+                    hook_hints,
+                )
+                flag_evaluation = FlagEvaluationDetails(
+                    flag_key=flag_key,
+                    value=default_value,
+                    reason=Reason.ERROR,
+                    error_code=ErrorCode.PROVIDER_NOT_READY,
+                )
+                return flag_evaluation
+            if status == ProviderStatus.FATAL:
+                error_hooks(
+                    flag_type,
+                    hook_context,
+                    ProviderFatalError(),
+                    reversed_merged_hooks,
+                    hook_hints,
+                )
+                flag_evaluation = FlagEvaluationDetails(
+                    flag_key=flag_key,
+                    value=default_value,
+                    reason=Reason.ERROR,
+                    error_code=ErrorCode.PROVIDER_FATAL,
+                )
+                return flag_evaluation
+
             # https://github.com/open-feature/spec/blob/main/specification/sections/03-evaluation-context.md
             # Any resulting evaluation context from a before hook will overwrite
             # duplicate fields defined globally, on the client, or in the invocation.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -223,6 +223,7 @@ def test_should_shortcircuit_if_provider_is_not_ready(
     spy_hook.error.assert_called_once()
     spy_hook.finally_after.assert_called_once()
 
+
 # Requirement 1.7.7
 def test_should_shortcircuit_if_provider_is_in_irrecoverable_error_state(
     no_op_provider_client, monkeypatch
@@ -244,6 +245,7 @@ def test_should_shortcircuit_if_provider_is_in_irrecoverable_error_state(
     assert flag_details.error_code == ErrorCode.PROVIDER_FATAL
     spy_hook.error.assert_called_once()
     spy_hook.finally_after.assert_called_once()
+
 
 def test_should_run_error_hooks_if_provider_returns_resolution_with_error_code():
     # Given

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -221,7 +221,7 @@ def test_should_shortcircuit_if_provider_is_not_ready(
     assert flag_details.reason == Reason.ERROR
     assert flag_details.error_code == ErrorCode.PROVIDER_NOT_READY
     spy_hook.error.assert_called_once()
-
+    spy_hook.finally_after.assert_called_once()
 
 # Requirement 1.7.7
 def test_should_shortcircuit_if_provider_is_in_irrecoverable_error_state(
@@ -243,7 +243,7 @@ def test_should_shortcircuit_if_provider_is_in_irrecoverable_error_state(
     assert flag_details.reason == Reason.ERROR
     assert flag_details.error_code == ErrorCode.PROVIDER_FATAL
     spy_hook.error.assert_called_once()
-
+    spy_hook.finally_after.assert_called_once()
 
 def test_should_run_error_hooks_if_provider_returns_resolution_with_error_code():
     # Given


### PR DESCRIPTION
## This PR
Calls the finally hooks after flag evaluation was attempted, even whe nthe provider is not in a ready state.

### Related Issue

Fixes #424 