### PR TITLE
chore: use centralized renovate config, downgrade release please

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v3
         id: release
         with:
           command: manifest

--- a/renovate.json
+++ b/renovate.json
@@ -1,30 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
-  ],
-  "semanticCommits": "enabled",
+    "github>open-feature/community-tooling"
+  ]
   "pep621": {
     "enabled": true
   },
   "pre-commit": {
     "enabled": true
-  },
-  "packageRules": [
-    {
-      "description": "Automerge non-major updates",
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "matchCurrentVersion": "!/^0/",
-      "automerge": true
-    },
-    {
-      "matchManagers": [
-        "github-actions"
-      ],
-      "automerge": true
-    }
-  ]
+  }
 }


### PR DESCRIPTION
Extends the [centralized Renovate config](https://github.com/open-feature/community-tooling/blob/main/renovate.json) and downgrades Release Please to v3.