### PR TITLE
chore: use existing submodule version for e2e tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ cov = [
     "cov-report",
 ]
 e2e = [
-    "git submodule add --force https://github.com/open-feature/spec.git spec",
+    "git submodule update --init --recursive",
     "cp spec/specification/assets/gherkin/* tests/features/",
     "behave tests/features/",
     "rm tests/features/*.feature",


### PR DESCRIPTION
## This PR

- modifies the submodule set in the E2E tests to use the existing `.gitmodule` configuration.

### Notes

The E2E tests will now use the submodule sha instead of pulling the latest. As a added benefit, Renovate should automagically open PRs when the spec repo is updated.
