### PR TITLE
chore: use keyword arguments, validate test

### DIFF
--- a/openfeature/client.py
+++ b/openfeature/client.py
@@ -701,11 +701,6 @@ class OpenFeatureClient:
         default_value: typing.Any,
         evaluation_context: typing.Optional[EvaluationContext] = None,
     ) -> FlagEvaluationDetails[typing.Any]:
-        args = (
-            flag_key,
-            default_value,
-            evaluation_context,
-        )
         get_details_callables_async: typing.Mapping[
             FlagType, GetDetailCallableAsync
         ] = {
@@ -719,7 +714,11 @@ class OpenFeatureClient:
         if not get_details_callable:
             raise GeneralError(error_message="Unknown flag type")
 
-        resolution = await get_details_callable(*args)
+        resolution = await get_details_callable(  # type: ignore[call-arg]
+            flag_key=flag_key,
+            default_value=default_value,
+            evaluation_context=evaluation_context,
+        )
         resolution.raise_for_error()
 
         # we need to check the get_args to be compatible with union types.
@@ -753,12 +752,6 @@ class OpenFeatureClient:
         :return: a FlagEvaluationDetails object with the fully evaluated flag from a
         provider
         """
-        args = (
-            flag_key,
-            default_value,
-            evaluation_context,
-        )
-
         get_details_callables: typing.Mapping[FlagType, GetDetailCallable] = {
             FlagType.BOOLEAN: provider.resolve_boolean_details,
             FlagType.INTEGER: provider.resolve_integer_details,
@@ -771,7 +764,11 @@ class OpenFeatureClient:
         if not get_details_callable:
             raise GeneralError(error_message="Unknown flag type")
 
-        resolution = get_details_callable(*args)
+        resolution = get_details_callable(  # type: ignore[call-arg]
+            flag_key=flag_key,
+            default_value=default_value,
+            evaluation_context=evaluation_context,
+        )
         resolution.raise_for_error()
 
         # we need to check the get_args to be compatible with union types.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -526,12 +526,20 @@ def test_client_should_merge_contexts():
     invocation_context = EvaluationContext(
         targeting_key="invocation", attributes={"invocation_attr": "invocation_value"}
     )
-    client.get_boolean_details("flag", False, invocation_context)
+    flag_input = "flag"
+    flag_default = False
+    client.get_boolean_details(flag_input, flag_default, invocation_context)
 
     # Retrieve the call arguments
     args, kwargs = provider.resolve_boolean_details.call_args
-    flag_key, default_value, context = args
+    flag_key, default_value, context = (
+        kwargs["flag_key"],
+        kwargs["default_value"],
+        kwargs["evaluation_context"],
+    )
 
+    assert flag_key == flag_input
+    assert default_value is flag_default
     assert context.targeting_key == "invocation"  # Last one in the merge chain
     assert context.attributes["global_attr"] == "global_value"
     assert context.attributes["transaction_attr"] == "transaction_value"


### PR DESCRIPTION
## This PR

Cleaning up some tech debt associated mentioned in this [comment](https://github.com/open-feature/python-sdk/pull/413#discussion_r1940218118)

* Dynamically resolve based on keyword arguments
* I wasn't able to find a configuration that worked on python 3.8/3.9 with mypy. I opted for ignoring the call-arg.
* If we'd prefer not ignore the error and keep positional arguments, feel free to close the PR.

### How to test
Standard testing (test, e2e, pre-commit)

