### PR TITLE
refactor: replace exception raising with error flag resolution

### DIFF
--- a/openfeature/flag_evaluation.py
+++ b/openfeature/flag_evaluation.py
@@ -4,7 +4,7 @@ import typing
 from dataclasses import dataclass, field
 
 from openfeature._backports.strenum import StrEnum
-from openfeature.exception import ErrorCode
+from openfeature.exception import ErrorCode, OpenFeatureError
 
 if typing.TYPE_CHECKING:  # pragma: no cover
     # resolves a circular dependency in type annotations
@@ -56,6 +56,11 @@ class FlagEvaluationDetails(typing.Generic[T_co]):
     error_code: typing.Optional[ErrorCode] = None
     error_message: typing.Optional[str] = None
 
+    def get_exception(self) -> typing.Optional[OpenFeatureError]:
+        if self.error_code:
+            return ErrorCode.to_exception(self.error_code, self.error_message or "")
+        return None
+
 
 @dataclass
 class FlagEvaluationOptions:
@@ -79,3 +84,14 @@ class FlagResolutionDetails(typing.Generic[U_co]):
         if self.error_code:
             raise ErrorCode.to_exception(self.error_code, self.error_message or "")
         return None
+
+    def to_flag_evaluation_details(self, flag_key: str) -> FlagEvaluationDetails[U_co]:
+        return FlagEvaluationDetails(
+            flag_key=flag_key,
+            value=self.value,
+            variant=self.variant,
+            flag_metadata=self.flag_metadata,
+            reason=self.reason,
+            error_code=self.error_code,
+            error_message=self.error_message,
+        )

--- a/openfeature/provider/in_memory_provider.py
+++ b/openfeature/provider/in_memory_provider.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass, field
 
 from openfeature._backports.strenum import StrEnum
 from openfeature.evaluation_context import EvaluationContext
-from openfeature.exception import FlagNotFoundError
+from openfeature.exception import ErrorCode
 from openfeature.flag_evaluation import FlagMetadata, FlagResolutionDetails, Reason
 from openfeature.hook import Hook
 from openfeature.provider import AbstractProvider, Metadata
@@ -74,7 +74,7 @@ class InMemoryProvider(AbstractProvider):
         default_value: bool,
         evaluation_context: typing.Optional[EvaluationContext] = None,
     ) -> FlagResolutionDetails[bool]:
-        return self._resolve(flag_key, evaluation_context)
+        return self._resolve(flag_key, default_value, evaluation_context)
 
     async def resolve_boolean_details_async(
         self,
@@ -82,7 +82,7 @@ class InMemoryProvider(AbstractProvider):
         default_value: bool,
         evaluation_context: typing.Optional[EvaluationContext] = None,
     ) -> FlagResolutionDetails[bool]:
-        return await self._resolve_async(flag_key, evaluation_context)
+        return await self._resolve_async(flag_key, default_value, evaluation_context)
 
     def resolve_string_details(
         self,
@@ -90,7 +90,7 @@ class InMemoryProvider(AbstractProvider):
         default_value: str,
         evaluation_context: typing.Optional[EvaluationContext] = None,
     ) -> FlagResolutionDetails[str]:
-        return self._resolve(flag_key, evaluation_context)
+        return self._resolve(flag_key, default_value, evaluation_context)
 
     async def resolve_string_details_async(
         self,
@@ -98,7 +98,7 @@ class InMemoryProvider(AbstractProvider):
         default_value: str,
         evaluation_context: typing.Optional[EvaluationContext] = None,
     ) -> FlagResolutionDetails[str]:
-        return await self._resolve_async(flag_key, evaluation_context)
+        return await self._resolve_async(flag_key, default_value, evaluation_context)
 
     def resolve_integer_details(
         self,
@@ -106,7 +106,7 @@ class InMemoryProvider(AbstractProvider):
         default_value: int,
         evaluation_context: typing.Optional[EvaluationContext] = None,
     ) -> FlagResolutionDetails[int]:
-        return self._resolve(flag_key, evaluation_context)
+        return self._resolve(flag_key, default_value, evaluation_context)
 
     async def resolve_integer_details_async(
         self,
@@ -114,7 +114,7 @@ class InMemoryProvider(AbstractProvider):
         default_value: int,
         evaluation_context: typing.Optional[EvaluationContext] = None,
     ) -> FlagResolutionDetails[int]:
-        return await self._resolve_async(flag_key, evaluation_context)
+        return await self._resolve_async(flag_key, default_value, evaluation_context)
 
     def resolve_float_details(
         self,
@@ -122,7 +122,7 @@ class InMemoryProvider(AbstractProvider):
         default_value: float,
         evaluation_context: typing.Optional[EvaluationContext] = None,
     ) -> FlagResolutionDetails[float]:
-        return self._resolve(flag_key, evaluation_context)
+        return self._resolve(flag_key, default_value, evaluation_context)
 
     async def resolve_float_details_async(
         self,
@@ -130,7 +130,7 @@ class InMemoryProvider(AbstractProvider):
         default_value: float,
         evaluation_context: typing.Optional[EvaluationContext] = None,
     ) -> FlagResolutionDetails[float]:
-        return await self._resolve_async(flag_key, evaluation_context)
+        return await self._resolve_async(flag_key, default_value, evaluation_context)
 
     def resolve_object_details(
         self,
@@ -138,7 +138,7 @@ class InMemoryProvider(AbstractProvider):
         default_value: typing.Union[dict, list],
         evaluation_context: typing.Optional[EvaluationContext] = None,
     ) -> FlagResolutionDetails[typing.Union[dict, list]]:
-        return self._resolve(flag_key, evaluation_context)
+        return self._resolve(flag_key, default_value, evaluation_context)
 
     async def resolve_object_details_async(
         self,
@@ -146,21 +146,28 @@ class InMemoryProvider(AbstractProvider):
         default_value: typing.Union[dict, list],
         evaluation_context: typing.Optional[EvaluationContext] = None,
     ) -> FlagResolutionDetails[typing.Union[dict, list]]:
-        return await self._resolve_async(flag_key, evaluation_context)
+        return await self._resolve_async(flag_key, default_value, evaluation_context)
 
     def _resolve(
         self,
         flag_key: str,
+        default_value: V,
         evaluation_context: typing.Optional[EvaluationContext],
     ) -> FlagResolutionDetails[V]:
         flag = self._flags.get(flag_key)
         if flag is None:
-            raise FlagNotFoundError(f"Flag '{flag_key}' not found")
+            return FlagResolutionDetails(
+                value=default_value,
+                reason=Reason.ERROR,
+                error_code=ErrorCode.FLAG_NOT_FOUND,
+                error_message=f"Flag '{flag_key}' not found",
+            )
         return flag.resolve(evaluation_context)
 
     async def _resolve_async(
         self,
         flag_key: str,
+        default_value: V,
         evaluation_context: typing.Optional[EvaluationContext],
     ) -> FlagResolutionDetails[V]:
-        return self._resolve(flag_key, evaluation_context)
+        return self._resolve(flag_key, default_value, evaluation_context)

--- a/tests/provider/test_in_memory_provider.py
+++ b/tests/provider/test_in_memory_provider.py
@@ -2,7 +2,7 @@ from numbers import Number
 
 import pytest
 
-from openfeature.exception import FlagNotFoundError
+from openfeature.exception import ErrorCode
 from openfeature.flag_evaluation import FlagResolutionDetails, Reason
 from openfeature.provider.in_memory_provider import InMemoryFlag, InMemoryProvider
 
@@ -22,11 +22,18 @@ async def test_should_handle_unknown_flags_correctly():
     # Given
     provider = InMemoryProvider({})
     # When
-    with pytest.raises(FlagNotFoundError):
-        provider.resolve_boolean_details(flag_key="Key", default_value=True)
-    with pytest.raises(FlagNotFoundError):
-        await provider.resolve_integer_details_async(flag_key="Key", default_value=1)
+    flag_sync = provider.resolve_boolean_details(flag_key="Key", default_value=True)
+    flag_async = await provider.resolve_boolean_details_async(
+        flag_key="Key", default_value=True
+    )
     # Then
+    assert flag_sync == flag_async
+    for flag in [flag_sync, flag_async]:
+        assert flag is not None
+        assert flag.value is True
+        assert flag.reason == Reason.ERROR
+        assert flag.error_code == ErrorCode.FLAG_NOT_FOUND
+        assert flag.error_message == "Flag 'Key' not found"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- this has actually no consequences for SDK users, because we already properly sending the errors inside the flag evaluation and only internally raised an exception. if someone used the privately marked methods, then it is a breaking change for them, but that's nothing we guarantee stability for.

### Related Issues

Fixes #466 

