### PR TITLE
chore: add codeowner file to be consistent with the rest of openfeature

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @open-feature/sdk-python-maintainers @open-feature/maintainers


### PR DESCRIPTION
All the other sdks use codeowner files to ensure proper approvals, we should also utilize this within python-sdk



