### PR TITLE
fix: merge transaction context into hook context evaluation context (#521)

### DIFF
--- a/tests/test_transaction_context_in_hooks.py
+++ b/tests/test_transaction_context_in_hooks.py
@@ -1,0 +1,51 @@
+from openfeature.api import (
+    set_provider,
+    set_transaction_context,
+    set_transaction_context_propagator,
+)
+from openfeature.client import OpenFeatureClient
+from openfeature.evaluation_context import EvaluationContext
+from openfeature.hook import Hook
+from openfeature.provider.no_op_provider import NoOpProvider
+from openfeature.transaction_context import ContextVarsTransactionContextPropagator
+
+
+class TransactionContextHook(Hook):
+    def __init__(self):
+        self.before_called = False
+        self.transaction_attr_value = None
+
+    def before(self, hook_context, hints):
+        self.before_called = True
+        # Check if the transaction context attribute is in the hook context
+        if "transaction_attr" in hook_context.evaluation_context.attributes:
+            self.transaction_attr_value = hook_context.evaluation_context.attributes[
+                "transaction_attr"
+            ]
+        return None
+
+
+def test_transaction_context_merged_into_hook_context():
+    """Test that transaction context is merged into the hook context's evaluation context."""
+    set_transaction_context_propagator(ContextVarsTransactionContextPropagator())
+
+    provider = NoOpProvider()
+    set_provider(provider)
+
+    client = OpenFeatureClient(domain=None, version=None)
+
+    hook = TransactionContextHook()
+    client.add_hooks([hook])
+
+    transaction_context = EvaluationContext(
+        targeting_key="transaction",
+        attributes={"transaction_attr": "transaction_value"},
+    )
+    set_transaction_context(transaction_context)
+
+    client.get_boolean_value(flag_key="test-flag", default_value=False)
+
+    assert hook.before_called, "Hook's before method was not called"
+    assert hook.transaction_attr_value == "transaction_value", (
+        "Transaction context attribute was not found in hook context"
+    )


### PR DESCRIPTION
## merge transaction context into hook context evaluation context

Currently during flag evaluation the transaction context is merged into the evaluation context here: https://github.com/open-feature/python-sdk/blob/288bd6bb34f2d5e857ae5b2b17f02f79276049c5/openfeature/client.py#L778
However the `hook_context.evaluation_context` is created before this, so it doesn't contain the attributes or targeting key that exists in the propagated transaction context. This is unexpected. It is also different than what [the JS implementation does.](https://github.com/open-feature/js-sdk/blob/d8bd93b6d5256445d12185d639e1cd91800a8a16/packages/server/src/client/internal/open-feature-client.ts#L277)

In this PR:
1. The transaction context is merged with the evaluation context  in `_establish_hooks_and_provider` before creating the hook context. 
2. The `_before_hooks_and_merge_context` method is renamed as `_run_before_hooks_and_update_context` to better reflect its updated functionality which is now restricted to just adding the before hooks results to the context.
3. Renamed a variable in `_run_before_hooks_and_update_context` which was inaptly named IMHO. The result of the before hooks is not the "invocation context".
4. Adds a test to verify the transaction context is properly merged into the hook context's evaluation context

This ensures that hooks have access to the complete evaluation context, including any attributes or targeting key from the transaction context.

### Related Issues

Fixes #521 

### Notes

Currently, both the Python sdk and the JS sdk do not update the hook context's `evaluation_context` field after running the before hooks. This is not explicitly required by the spec here: https://openfeature.dev/specification/sections/evaluation-context/#requirement-323
or here:
https://openfeature.dev/specification/sections/hooks

However it seems to me to be a safe assumption that if the before hooks update the evaluation context then the hook context should reference this updated evaluation context instead of referencing the evaluation context as it was before the before hooks ran. I can open a different issue about this