### PR TITLE
chore: replace deprecated typing aliases

### DIFF
--- a/openfeature/_event_support.py
+++ b/openfeature/_event_support.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import threading
+import typing
 from collections import defaultdict
-from typing import TYPE_CHECKING
 
 from openfeature.event import (
     EventDetails,
@@ -12,7 +12,7 @@ from openfeature.event import (
 )
 from openfeature.provider import FeatureProvider, ProviderStatus
 
-if TYPE_CHECKING:
+if typing.TYPE_CHECKING:
     from openfeature.client import OpenFeatureClient
 
 

--- a/openfeature/client.py
+++ b/openfeature/client.py
@@ -1,6 +1,6 @@
 import logging
 import typing
-from collections.abc import Awaitable, Sequence
+from collections.abc import Awaitable, Mapping, Sequence
 from dataclasses import dataclass
 from itertools import chain
 
@@ -345,11 +345,11 @@ class OpenFeatureClient:
         self,
         flag_key: str,
         default_value: typing.Union[
-            Sequence[FlagValueType], typing.Mapping[str, FlagValueType]
+            Sequence[FlagValueType], Mapping[str, FlagValueType]
         ],
         evaluation_context: typing.Optional[EvaluationContext] = None,
         flag_evaluation_options: typing.Optional[FlagEvaluationOptions] = None,
-    ) -> typing.Union[Sequence[FlagValueType], typing.Mapping[str, FlagValueType]]:
+    ) -> typing.Union[Sequence[FlagValueType], Mapping[str, FlagValueType]]:
         return self.get_object_details(
             flag_key,
             default_value,
@@ -361,11 +361,11 @@ class OpenFeatureClient:
         self,
         flag_key: str,
         default_value: typing.Union[
-            Sequence[FlagValueType], typing.Mapping[str, FlagValueType]
+            Sequence[FlagValueType], Mapping[str, FlagValueType]
         ],
         evaluation_context: typing.Optional[EvaluationContext] = None,
         flag_evaluation_options: typing.Optional[FlagEvaluationOptions] = None,
-    ) -> typing.Union[Sequence[FlagValueType], typing.Mapping[str, FlagValueType]]:
+    ) -> typing.Union[Sequence[FlagValueType], Mapping[str, FlagValueType]]:
         details = await self.get_object_details_async(
             flag_key,
             default_value,
@@ -378,12 +378,12 @@ class OpenFeatureClient:
         self,
         flag_key: str,
         default_value: typing.Union[
-            Sequence[FlagValueType], typing.Mapping[str, FlagValueType]
+            Sequence[FlagValueType], Mapping[str, FlagValueType]
         ],
         evaluation_context: typing.Optional[EvaluationContext] = None,
         flag_evaluation_options: typing.Optional[FlagEvaluationOptions] = None,
     ) -> FlagEvaluationDetails[
-        typing.Union[Sequence[FlagValueType], typing.Mapping[str, FlagValueType]]
+        typing.Union[Sequence[FlagValueType], Mapping[str, FlagValueType]]
     ]:
         return self.evaluate_flag_details(
             FlagType.OBJECT,
@@ -397,12 +397,12 @@ class OpenFeatureClient:
         self,
         flag_key: str,
         default_value: typing.Union[
-            Sequence[FlagValueType], typing.Mapping[str, FlagValueType]
+            Sequence[FlagValueType], Mapping[str, FlagValueType]
         ],
         evaluation_context: typing.Optional[EvaluationContext] = None,
         flag_evaluation_options: typing.Optional[FlagEvaluationOptions] = None,
     ) -> FlagEvaluationDetails[
-        typing.Union[Sequence[FlagValueType], typing.Mapping[str, FlagValueType]]
+        typing.Union[Sequence[FlagValueType], Mapping[str, FlagValueType]]
     ]:
         return await self.evaluate_flag_details_async(
             FlagType.OBJECT,
@@ -472,7 +472,7 @@ class OpenFeatureClient:
             )
         ]
         # after, error, finally: Provider, Invocation, Client, API
-        reversed_merged_hooks_and_context = merged_hooks_and_context[:]
+        reversed_merged_hooks_and_context = merged_hooks_and_context.copy()
         reversed_merged_hooks_and_context.reverse()
 
         return (
@@ -567,10 +567,10 @@ class OpenFeatureClient:
         self,
         flag_type: FlagType,
         flag_key: str,
-        default_value: typing.Mapping[str, "FlagValueType"],
+        default_value: Mapping[str, "FlagValueType"],
         evaluation_context: typing.Optional[EvaluationContext] = None,
         flag_evaluation_options: typing.Optional[FlagEvaluationOptions] = None,
-    ) -> FlagEvaluationDetails[typing.Mapping[str, "FlagValueType"]]: ...
+    ) -> FlagEvaluationDetails[Mapping[str, "FlagValueType"]]: ...
 
     async def evaluate_flag_details_async(
         self,
@@ -743,10 +743,10 @@ class OpenFeatureClient:
         self,
         flag_type: FlagType,
         flag_key: str,
-        default_value: typing.Mapping[str, "FlagValueType"],
+        default_value: Mapping[str, "FlagValueType"],
         evaluation_context: typing.Optional[EvaluationContext] = None,
         flag_evaluation_options: typing.Optional[FlagEvaluationOptions] = None,
-    ) -> FlagEvaluationDetails[typing.Mapping[str, "FlagValueType"]]: ...
+    ) -> FlagEvaluationDetails[Mapping[str, "FlagValueType"]]: ...
 
     def evaluate_flag_details(
         self,
@@ -874,9 +874,7 @@ class OpenFeatureClient:
         default_value: FlagValueType,
         evaluation_context: typing.Optional[EvaluationContext] = None,
     ) -> FlagEvaluationDetails[FlagValueType]:
-        get_details_callables_async: typing.Mapping[
-            FlagType, ResolveDetailsCallableAsync
-        ] = {
+        get_details_callables_async: Mapping[FlagType, ResolveDetailsCallableAsync] = {
             FlagType.BOOLEAN: provider.resolve_boolean_details_async,
             FlagType.INTEGER: provider.resolve_integer_details_async,
             FlagType.FLOAT: provider.resolve_float_details_async,
@@ -931,7 +929,7 @@ class OpenFeatureClient:
         :return: a FlagEvaluationDetails object with the fully evaluated flag from a
         provider
         """
-        get_details_callables: typing.Mapping[FlagType, ResolveDetailsCallable] = {
+        get_details_callables: Mapping[FlagType, ResolveDetailsCallable] = {
             FlagType.BOOLEAN: provider.resolve_boolean_details,
             FlagType.INTEGER: provider.resolve_integer_details,
             FlagType.FLOAT: provider.resolve_float_details,
@@ -986,9 +984,9 @@ def _typecheck_flag_value(
         FlagType.FLOAT: float,
         FlagType.INTEGER: int,
     }
-    _type = type_map.get(flag_type)
-    if not _type:
+    py_type = type_map.get(flag_type)
+    if not py_type:
         return GeneralError(error_message="Unknown flag type")
-    if not isinstance(value, _type):
-        return TypeMismatchError(f"Expected type {_type} but got {type(value)}")
+    if not isinstance(value, py_type):
+        return TypeMismatchError(f"Expected type {py_type} but got {type(value)}")
     return None

--- a/openfeature/evaluation_context/__init__.py
+++ b/openfeature/evaluation_context/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import typing
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
 
@@ -17,16 +17,14 @@ EvaluationContextAttribute = typing.Union[
     str,
     datetime,
     Sequence["EvaluationContextAttribute"],
-    typing.Mapping[str, "EvaluationContextAttribute"],
+    Mapping[str, "EvaluationContextAttribute"],
 ]
 
 
 @dataclass
 class EvaluationContext:
     targeting_key: typing.Optional[str] = None
-    attributes: typing.Mapping[str, EvaluationContextAttribute] = field(
-        default_factory=dict
-    )
+    attributes: Mapping[str, EvaluationContextAttribute] = field(default_factory=dict)
 
     def merge(self, ctx2: EvaluationContext) -> EvaluationContext:
         if not (self and ctx2):

--- a/openfeature/event.py
+++ b/openfeature/event.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import typing
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Callable, Optional, Union
 
 from openfeature.exception import ErrorCode
 
@@ -18,19 +19,23 @@ class ProviderEvent(Enum):
 
 @dataclass
 class ProviderEventDetails:
-    flags_changed: Optional[list[str]] = None
-    message: Optional[str] = None
-    error_code: Optional[ErrorCode] = None
-    metadata: dict[str, Union[bool, str, int, float]] = field(default_factory=dict)
+    flags_changed: typing.Optional[list[str]] = None
+    message: typing.Optional[str] = None
+    error_code: typing.Optional[ErrorCode] = None
+    metadata: dict[str, typing.Union[bool, str, int, float]] = field(
+        default_factory=dict
+    )
 
 
 @dataclass
 class EventDetails(ProviderEventDetails):
     provider_name: str = ""
-    flags_changed: Optional[list[str]] = None
-    message: Optional[str] = None
-    error_code: Optional[ErrorCode] = None
-    metadata: dict[str, Union[bool, str, int, float]] = field(default_factory=dict)
+    flags_changed: typing.Optional[list[str]] = None
+    message: typing.Optional[str] = None
+    error_code: typing.Optional[ErrorCode] = None
+    metadata: dict[str, typing.Union[bool, str, int, float]] = field(
+        default_factory=dict
+    )
 
     @classmethod
     def from_provider_event_details(

--- a/openfeature/exception.py
+++ b/openfeature/exception.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import typing
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 
 from openfeature._backports.strenum import StrEnum
 
@@ -174,7 +174,7 @@ class ErrorCode(StrEnum):
     INVALID_CONTEXT = "INVALID_CONTEXT"
     GENERAL = "GENERAL"
 
-    __exceptions__: Mapping[str, typing.Callable[[str], OpenFeatureError]] = {
+    __exceptions__: Mapping[str, Callable[[str], OpenFeatureError]] = {
         PROVIDER_NOT_READY: ProviderNotReadyError,
         PROVIDER_FATAL: ProviderFatalError,
         FLAG_NOT_FOUND: FlagNotFoundError,

--- a/openfeature/flag_evaluation.py
+++ b/openfeature/flag_evaluation.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import typing
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 
 from openfeature._backports.strenum import StrEnum
@@ -42,14 +42,14 @@ class Reason(StrEnum):
     UNKNOWN = "UNKNOWN"
 
 
-FlagMetadata = typing.Mapping[str, typing.Union[bool, int, float, str]]
+FlagMetadata = Mapping[str, typing.Union[bool, int, float, str]]
 FlagValueType = typing.Union[
     bool,
     int,
     float,
     str,
     Sequence["FlagValueType"],
-    typing.Mapping[str, "FlagValueType"],
+    Mapping[str, "FlagValueType"],
 ]
 
 T_co = typing.TypeVar("T_co", covariant=True)

--- a/openfeature/hook/__init__.py
+++ b/openfeature/hook/__init__.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
 import typing
-from collections.abc import MutableMapping, Sequence
+from collections.abc import Mapping, MutableMapping, Sequence
 from datetime import datetime
 from enum import Enum
-from typing import TYPE_CHECKING
 
 from openfeature.evaluation_context import EvaluationContext
 from openfeature.flag_evaluation import FlagEvaluationDetails, FlagType, FlagValueType
 
-if TYPE_CHECKING:
+if typing.TYPE_CHECKING:
     from openfeature.client import ClientMetadata
     from openfeature.provider.metadata import Metadata
 
@@ -77,10 +76,10 @@ HookHintValue = typing.Union[
     str,
     datetime,
     Sequence["HookHintValue"],
-    typing.Mapping[str, "HookHintValue"],
+    Mapping[str, "HookHintValue"],
 ]
 
-HookHints = typing.Mapping[str, HookHintValue]
+HookHints = Mapping[str, HookHintValue]
 
 
 class Hook:

--- a/openfeature/provider/__init__.py
+++ b/openfeature/provider/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import typing
 from abc import abstractmethod
-from collections.abc import Sequence
+from collections.abc import Callable, Mapping, Sequence
 from enum import Enum
 
 from openfeature.evaluation_context import EvaluationContext
@@ -29,9 +29,7 @@ class ProviderStatus(Enum):
 class FeatureProvider(typing.Protocol):  # pragma: no cover
     def attach(
         self,
-        on_emit: typing.Callable[
-            [FeatureProvider, ProviderEvent, ProviderEventDetails], None
-        ],
+        on_emit: Callable[[FeatureProvider, ProviderEvent, ProviderEventDetails], None],
     ) -> None: ...
 
     def detach(self) -> None: ...
@@ -104,22 +102,22 @@ class FeatureProvider(typing.Protocol):  # pragma: no cover
         self,
         flag_key: str,
         default_value: typing.Union[
-            Sequence[FlagValueType], typing.Mapping[str, FlagValueType]
+            Sequence[FlagValueType], Mapping[str, FlagValueType]
         ],
         evaluation_context: typing.Optional[EvaluationContext] = None,
     ) -> FlagResolutionDetails[
-        typing.Union[Sequence[FlagValueType], typing.Mapping[str, FlagValueType]]
+        typing.Union[Sequence[FlagValueType], Mapping[str, FlagValueType]]
     ]: ...
 
     async def resolve_object_details_async(
         self,
         flag_key: str,
         default_value: typing.Union[
-            Sequence[FlagValueType], typing.Mapping[str, FlagValueType]
+            Sequence[FlagValueType], Mapping[str, FlagValueType]
         ],
         evaluation_context: typing.Optional[EvaluationContext] = None,
     ) -> FlagResolutionDetails[
-        typing.Union[Sequence[FlagValueType], typing.Mapping[str, FlagValueType]]
+        typing.Union[Sequence[FlagValueType], Mapping[str, FlagValueType]]
     ]: ...
 
 
@@ -130,9 +128,7 @@ class AbstractProvider(FeatureProvider):
 
     def attach(
         self,
-        on_emit: typing.Callable[
-            [FeatureProvider, ProviderEvent, ProviderEventDetails], None
-        ],
+        on_emit: Callable[[FeatureProvider, ProviderEvent, ProviderEventDetails], None],
     ) -> None:
         self._on_emit = on_emit
 
@@ -226,11 +222,11 @@ class AbstractProvider(FeatureProvider):
         self,
         flag_key: str,
         default_value: typing.Union[
-            Sequence[FlagValueType], typing.Mapping[str, FlagValueType]
+            Sequence[FlagValueType], Mapping[str, FlagValueType]
         ],
         evaluation_context: typing.Optional[EvaluationContext] = None,
     ) -> FlagResolutionDetails[
-        typing.Union[Sequence[FlagValueType], typing.Mapping[str, FlagValueType]]
+        typing.Union[Sequence[FlagValueType], Mapping[str, FlagValueType]]
     ]:
         pass
 
@@ -238,11 +234,11 @@ class AbstractProvider(FeatureProvider):
         self,
         flag_key: str,
         default_value: typing.Union[
-            Sequence[FlagValueType], typing.Mapping[str, FlagValueType]
+            Sequence[FlagValueType], Mapping[str, FlagValueType]
         ],
         evaluation_context: typing.Optional[EvaluationContext] = None,
     ) -> FlagResolutionDetails[
-        typing.Union[Sequence[FlagValueType], typing.Mapping[str, FlagValueType]]
+        typing.Union[Sequence[FlagValueType], Mapping[str, FlagValueType]]
     ]:
         return self.resolve_object_details(flag_key, default_value, evaluation_context)
 

--- a/openfeature/provider/in_memory_provider.py
+++ b/openfeature/provider/in_memory_provider.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import typing
-from collections.abc import Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 
 from openfeature._backports.strenum import StrEnum
@@ -36,9 +36,7 @@ class InMemoryFlag(typing.Generic[T_co]):
     flag_metadata: FlagMetadata = field(default_factory=dict)
     state: State = State.ENABLED
     context_evaluator: typing.Optional[
-        typing.Callable[
-            [InMemoryFlag[T_co], EvaluationContext], FlagResolutionDetails[T_co]
-        ]
+        Callable[[InMemoryFlag[T_co], EvaluationContext], FlagResolutionDetails[T_co]]
     ] = None
 
     def resolve(
@@ -142,11 +140,11 @@ class InMemoryProvider(AbstractProvider):
         self,
         flag_key: str,
         default_value: typing.Union[
-            Sequence[FlagValueType], typing.Mapping[str, FlagValueType]
+            Sequence[FlagValueType], Mapping[str, FlagValueType]
         ],
         evaluation_context: typing.Optional[EvaluationContext] = None,
     ) -> FlagResolutionDetails[
-        typing.Union[Sequence[FlagValueType], typing.Mapping[str, FlagValueType]]
+        typing.Union[Sequence[FlagValueType], Mapping[str, FlagValueType]]
     ]:
         return self._resolve(flag_key, default_value, evaluation_context)
 
@@ -154,11 +152,11 @@ class InMemoryProvider(AbstractProvider):
         self,
         flag_key: str,
         default_value: typing.Union[
-            Sequence[FlagValueType], typing.Mapping[str, FlagValueType]
+            Sequence[FlagValueType], Mapping[str, FlagValueType]
         ],
         evaluation_context: typing.Optional[EvaluationContext] = None,
     ) -> FlagResolutionDetails[
-        typing.Union[Sequence[FlagValueType], typing.Mapping[str, FlagValueType]]
+        typing.Union[Sequence[FlagValueType], Mapping[str, FlagValueType]]
     ]:
         return await self._resolve_async(flag_key, default_value, evaluation_context)
 

--- a/openfeature/provider/no_op_provider.py
+++ b/openfeature/provider/no_op_provider.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import typing
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 
 from openfeature.flag_evaluation import FlagResolutionDetails, Reason
 from openfeature.provider import AbstractProvider
@@ -75,11 +75,11 @@ class NoOpProvider(AbstractProvider):
         self,
         flag_key: str,
         default_value: typing.Union[
-            Sequence[FlagValueType], typing.Mapping[str, FlagValueType]
+            Sequence[FlagValueType], Mapping[str, FlagValueType]
         ],
         evaluation_context: typing.Optional[EvaluationContext] = None,
     ) -> FlagResolutionDetails[
-        typing.Union[Sequence[FlagValueType], typing.Mapping[str, FlagValueType]]
+        typing.Union[Sequence[FlagValueType], Mapping[str, FlagValueType]]
     ]:
         return FlagResolutionDetails(
             value=default_value,

--- a/openfeature/transaction_context/context_var_transaction_context_propagator.py
+++ b/openfeature/transaction_context/context_var_transaction_context_propagator.py
@@ -1,5 +1,5 @@
+import typing
 from contextvars import ContextVar
-from typing import Optional
 
 from openfeature.evaluation_context import EvaluationContext
 from openfeature.transaction_context.transaction_context_propagator import (
@@ -8,8 +8,8 @@ from openfeature.transaction_context.transaction_context_propagator import (
 
 
 class ContextVarsTransactionContextPropagator(TransactionContextPropagator):
-    _transaction_context_var: ContextVar[Optional[EvaluationContext]] = ContextVar(
-        "transaction_context", default=None
+    _transaction_context_var: ContextVar[typing.Optional[EvaluationContext]] = (
+        ContextVar("transaction_context", default=None)
     )
 
     def get_transaction_context(self) -> EvaluationContext:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ select = [
     "FLY",
     "FURB",
     "I",
+    "ICN003",
     "LOG",
     "N",
     "PERF",
@@ -98,6 +99,7 @@ select = [
     "SIM",
     "T10",
     "T20",
+    "TID251",
     "UP",
     "W",
     "YTT",
@@ -116,6 +118,18 @@ max-statements = 30
 [tool.ruff.lint.pyupgrade]
 # Preserve types, even if a file imports `from __future__ import annotations`.
 keep-runtime-typing = true
+
+[tool.ruff.lint.flake8-import-conventions]
+banned-from = ["typing"]
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"typing.Awaitable".msg = "Use collections.abc.Awaitable instead"
+"typing.Callable".msg = "Use collections.abc.Callable instead"
+"typing.Collection".msg = "Use collections.abc.Collection instead"
+"typing.Mapping".msg = "Use collections.abc.Mapping instead"
+"typing.Sequence".msg = "Use collections.abc.Sequence instead"
+"typing.MutableMapping".msg = "Use collections.abc.MutableMapping instead"
+"typing.MutableSequence".msg = "Use collections.abc.MutableSequence instead"
 
 [project.scripts]
 # workaround while UV doesn't support scripts directly in the pyproject.toml

--- a/tests/provider/test_provider_compatibility.py
+++ b/tests/provider/test_provider_compatibility.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+import typing
 
 import pytest
 
@@ -19,7 +19,7 @@ class SynchronousProvider(AbstractProvider):
         self,
         flag_key: str,
         default_value: bool,
-        evaluation_context: Optional[EvaluationContext] = None,
+        evaluation_context: typing.Optional[EvaluationContext] = None,
     ) -> FlagResolutionDetails[bool]:
         return FlagResolutionDetails(value=True)
 
@@ -27,7 +27,7 @@ class SynchronousProvider(AbstractProvider):
         self,
         flag_key: str,
         default_value: str,
-        evaluation_context: Optional[EvaluationContext] = None,
+        evaluation_context: typing.Optional[EvaluationContext] = None,
     ) -> FlagResolutionDetails[str]:
         return FlagResolutionDetails(value="string")
 
@@ -35,7 +35,7 @@ class SynchronousProvider(AbstractProvider):
         self,
         flag_key: str,
         default_value: int,
-        evaluation_context: Optional[EvaluationContext] = None,
+        evaluation_context: typing.Optional[EvaluationContext] = None,
     ) -> FlagResolutionDetails[int]:
         return FlagResolutionDetails(value=1)
 
@@ -43,16 +43,16 @@ class SynchronousProvider(AbstractProvider):
         self,
         flag_key: str,
         default_value: float,
-        evaluation_context: Optional[EvaluationContext] = None,
+        evaluation_context: typing.Optional[EvaluationContext] = None,
     ) -> FlagResolutionDetails[float]:
         return FlagResolutionDetails(value=10.0)
 
     def resolve_object_details(
         self,
         flag_key: str,
-        default_value: Union[dict, list],
-        evaluation_context: Optional[EvaluationContext] = None,
-    ) -> FlagResolutionDetails[Union[dict, list]]:
+        default_value: typing.Union[dict, list],
+        evaluation_context: typing.Optional[EvaluationContext] = None,
+    ) -> FlagResolutionDetails[typing.Union[dict, list]]:
         return FlagResolutionDetails(value={"key": "value"})
 
 
@@ -92,7 +92,7 @@ async def test_sync_provider_can_be_extended_async():
             self,
             flag_key: str,
             default_value: bool,
-            evaluation_context: Optional[EvaluationContext] = None,
+            evaluation_context: typing.Optional[EvaluationContext] = None,
         ) -> FlagResolutionDetails[bool]:
             return FlagResolutionDetails(value=False)
 
@@ -116,7 +116,7 @@ def test_sync_methods_enforced_for_async_providers():
             self,
             flag_key: str,
             default_value: bool,
-            evaluation_context: Optional[EvaluationContext] = None,
+            evaluation_context: typing.Optional[EvaluationContext] = None,
         ) -> FlagResolutionDetails[bool]:
             return FlagResolutionDetails(value=True)
 
@@ -130,7 +130,7 @@ def test_sync_methods_enforced_for_async_providers():
     assert exception_message.startswith(
         "Can't instantiate abstract class AsyncProvider"
     )
-    assert exception_message.__contains__("resolve_boolean_details")
+    assert "resolve_boolean_details" in exception_message
 
 
 @pytest.mark.asyncio
@@ -144,7 +144,7 @@ async def test_async_provider_not_implemented_exception_workaround():
             self,
             flag_key: str,
             default_value: bool,
-            evaluation_context: Optional[EvaluationContext] = None,
+            evaluation_context: typing.Optional[EvaluationContext] = None,
         ) -> FlagResolutionDetails[bool]:
             return FlagResolutionDetails(value=True)
 
@@ -152,7 +152,7 @@ async def test_async_provider_not_implemented_exception_workaround():
             self,
             flag_key: str,
             default_value: bool,
-            evaluation_context: Optional[EvaluationContext] = None,
+            evaluation_context: typing.Optional[EvaluationContext] = None,
         ) -> FlagResolutionDetails[bool]:
             raise NotImplementedError("Use the async method")
 
@@ -160,7 +160,7 @@ async def test_async_provider_not_implemented_exception_workaround():
             self,
             flag_key: str,
             default_value: str,
-            evaluation_context: Optional[EvaluationContext] = None,
+            evaluation_context: typing.Optional[EvaluationContext] = None,
         ) -> FlagResolutionDetails[str]:
             raise NotImplementedError("Use the async method")
 
@@ -168,7 +168,7 @@ async def test_async_provider_not_implemented_exception_workaround():
             self,
             flag_key: str,
             default_value: int,
-            evaluation_context: Optional[EvaluationContext] = None,
+            evaluation_context: typing.Optional[EvaluationContext] = None,
         ) -> FlagResolutionDetails[int]:
             raise NotImplementedError("Use the async method")
 
@@ -176,16 +176,16 @@ async def test_async_provider_not_implemented_exception_workaround():
             self,
             flag_key: str,
             default_value: float,
-            evaluation_context: Optional[EvaluationContext] = None,
+            evaluation_context: typing.Optional[EvaluationContext] = None,
         ) -> FlagResolutionDetails[float]:
             raise NotImplementedError("Use the async method")
 
         def resolve_object_details(
             self,
             flag_key: str,
-            default_value: Union[dict, list],
-            evaluation_context: Optional[EvaluationContext] = None,
-        ) -> FlagResolutionDetails[Union[dict, list]]:
+            default_value: typing.Union[dict, list],
+            evaluation_context: typing.Optional[EvaluationContext] = None,
+        ) -> FlagResolutionDetails[typing.Union[dict, list]]:
             raise NotImplementedError("Use the async method")
 
     # When


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->

- also added 2 ruff rules to make sure those aliases won't be imported again



