### PR TITLE
fix: mimic the behavior of stdlib StrEnum.__str__ in backport

### DIFF
--- a/openfeature/_backports/strenum.py
+++ b/openfeature/_backports/strenum.py
@@ -11,4 +11,5 @@ else:
         Backport StrEnum for Python <3.11
         """
 
-        pass
+        def __str__(self) -> str:
+            return str(self.value)

--- a/tests/test_exception.py
+++ b/tests/test_exception.py
@@ -1,0 +1,5 @@
+from openfeature.exception import ErrorCode
+
+
+def test_error_code_str():
+    assert str(ErrorCode.GENERAL) == "GENERAL"

--- a/tests/test_flag_evaluation.py
+++ b/tests/test_flag_evaluation.py
@@ -54,3 +54,7 @@ def test_evaluation_details_reason_should_be_a_string_when_set():
 
     # Then
     assert Reason.STATIC == flag_details.reason  # noqa: SIM300
+
+
+def test_reason_str():
+    assert str(Reason.DEFAULT) == "DEFAULT"


### PR DESCRIPTION
Copies the behavior of Python 3.11+ StrEnum by implementing `__str__`.

This is to ensure the value of `str(Reason.DEFAULT)` or `str(ErrorCode.GENERAL)` remains the same regardless of Python version.