### PR TITLE
feat: implement Multi-Provider

### DIFF
--- a/openfeature/provider/__init__.py
+++ b/openfeature/provider/__init__.py
@@ -11,11 +11,26 @@ from openfeature.flag_evaluation import FlagResolutionDetails
 from openfeature.hook import Hook
 
 from .metadata import Metadata
+from .multi_provider import (
+    EvaluationStrategy,
+    FirstMatchStrategy,
+    MultiProvider,
+    ProviderEntry,
+)
 
 if typing.TYPE_CHECKING:
     from openfeature.flag_evaluation import FlagValueType
 
-__all__ = ["AbstractProvider", "FeatureProvider", "Metadata", "ProviderStatus"]
+__all__ = [
+    "AbstractProvider",
+    "EvaluationStrategy",
+    "FeatureProvider",
+    "FirstMatchStrategy",
+    "Metadata",
+    "MultiProvider",
+    "ProviderEntry",
+    "ProviderStatus",
+]
 
 
 class ProviderStatus(Enum):

--- a/openfeature/provider/multi_provider.py
+++ b/openfeature/provider/multi_provider.py
@@ -10,7 +10,7 @@ See: https://openfeature.dev/specification/appendix-a/#multi-provider
 from __future__ import annotations
 
 import typing
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Awaitable, Callable, Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 
@@ -316,7 +316,7 @@ class MultiProvider(AbstractProvider):
         flag_key: str,
         default_value: FlagValueType,
         evaluation_context: EvaluationContext | None,
-        resolve_fn: Callable[[FeatureProvider, str, FlagValueType, EvaluationContext | None], typing.Awaitable[FlagResolutionDetails[FlagValueType]]],
+        resolve_fn: Callable[[FeatureProvider, str, FlagValueType, EvaluationContext | None], Awaitable[FlagResolutionDetails[FlagValueType]]],
     ) -> FlagResolutionDetails[FlagValueType]:
         """
         Async evaluation logic that properly awaits provider async methods.

--- a/openfeature/provider/multi_provider.py
+++ b/openfeature/provider/multi_provider.py
@@ -1,0 +1,352 @@
+"""
+Multi-Provider implementation for OpenFeature Python SDK.
+
+This provider wraps multiple underlying providers, allowing a single client
+to interact with multiple flag sources simultaneously.
+
+See: https://openfeature.dev/specification/appendix-a/#multi-provider
+"""
+
+from __future__ import annotations
+
+import asyncio
+import typing
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+
+from openfeature.evaluation_context import EvaluationContext
+from openfeature.event import ProviderEvent, ProviderEventDetails
+from openfeature.exception import GeneralError
+from openfeature.flag_evaluation import FlagResolutionDetails, FlagValueType, Reason
+from openfeature.hook import Hook
+from openfeature.provider import AbstractProvider, FeatureProvider, Metadata, ProviderStatus
+
+__all__ = ["MultiProvider", "ProviderEntry", "FirstMatchStrategy", "EvaluationStrategy"]
+
+
+@dataclass
+class ProviderEntry:
+    """Configuration for a provider in the Multi-Provider."""
+
+    provider: FeatureProvider
+    name: str | None = None
+
+
+class EvaluationStrategy(typing.Protocol):
+    """
+    Strategy interface for determining which provider's result to use.
+    
+    Strategies can be 'sequential' (evaluate one at a time, stop early) or
+    'parallel' (evaluate all simultaneously).
+    """
+
+    run_mode: typing.Literal["sequential", "parallel"]
+
+    def should_use_result(
+        self,
+        flag_key: str,
+        provider_name: str,
+        result: FlagResolutionDetails,
+    ) -> bool:
+        """
+        Determine if this result should be used (and stop evaluation if sequential).
+        
+        :param flag_key: The flag being evaluated
+        :param provider_name: Name of the provider that returned this result
+        :param result: The resolution details from the provider
+        :return: True if this result should be used as the final result
+        """
+        ...
+
+
+class FirstMatchStrategy:
+    """
+    Uses the first successful result from providers (in order).
+    
+    In sequential mode, stops at the first non-error result.
+    In parallel mode, picks the first successful result from the ordered list.
+    """
+
+    run_mode: typing.Literal["sequential", "parallel"] = "sequential"
+
+    def should_use_result(
+        self,
+        flag_key: str,
+        provider_name: str,
+        result: FlagResolutionDetails,
+    ) -> bool:
+        """Use the first result that doesn't have an error."""
+        return result.reason != Reason.ERROR
+
+
+class MultiProvider(AbstractProvider):
+    """
+    A provider that aggregates multiple underlying providers.
+    
+    Evaluations are delegated to underlying providers based on the configured
+    strategy (default: FirstMatchStrategy in sequential mode).
+    
+    Example:
+        provider_a = SomeProvider()
+        provider_b = AnotherProvider()
+        
+        multi = MultiProvider([
+            ProviderEntry(provider_a, name="primary"),
+            ProviderEntry(provider_b, name="fallback")
+        ])
+        
+        api.set_provider(multi)
+    """
+
+    def __init__(
+        self,
+        providers: list[ProviderEntry],
+        strategy: EvaluationStrategy | None = None,
+    ):
+        """
+        Initialize the Multi-Provider.
+        
+        :param providers: List of ProviderEntry objects defining the providers
+        :param strategy: Evaluation strategy (defaults to FirstMatchStrategy)
+        """
+        super().__init__()
+        
+        if not providers:
+            raise ValueError("At least one provider must be provided")
+        
+        self.strategy = strategy or FirstMatchStrategy()
+        self._registered_providers: list[tuple[str, FeatureProvider]] = []
+        self._register_providers(providers)
+
+    def _register_providers(self, providers: list[ProviderEntry]) -> None:
+        """
+        Register providers with unique names.
+        
+        Names are determined by:
+        1. Explicit name in ProviderEntry
+        2. provider.get_metadata().name if unique
+        3. {metadata.name}_{index} if not unique
+        """
+        # Count providers by their metadata name to detect duplicates
+        name_counts: dict[str, int] = {}
+        for entry in providers:
+            metadata_name = entry.provider.get_metadata().name or "provider"
+            name_counts[metadata_name] = name_counts.get(metadata_name, 0) + 1
+
+        # Track used names to prevent conflicts
+        used_names: set[str] = set()
+        name_indices: dict[str, int] = {}
+
+        for entry in providers:
+            metadata_name = entry.provider.get_metadata().name or "provider"
+            
+            if entry.name:
+                # Explicit name provided
+                if entry.name in used_names:
+                    raise ValueError(f"Provider name '{entry.name}' is not unique")
+                final_name = entry.name
+            elif name_counts[metadata_name] == 1:
+                # Metadata name is unique
+                final_name = metadata_name
+            else:
+                # Multiple providers with same metadata name, add index
+                name_indices[metadata_name] = name_indices.get(metadata_name, 0) + 1
+                final_name = f"{metadata_name}_{name_indices[metadata_name]}"
+            
+            used_names.add(final_name)
+            self._registered_providers.append((final_name, entry.provider))
+
+    def get_metadata(self) -> Metadata:
+        """Return metadata including all wrapped provider metadata."""
+        return Metadata(name="MultiProvider")
+
+    def get_provider_hooks(self) -> list[Hook]:
+        """Aggregate hooks from all providers."""
+        hooks: list[Hook] = []
+        for _, provider in self._registered_providers:
+            hooks.extend(provider.get_provider_hooks())
+        return hooks
+
+    def initialize(self, evaluation_context: EvaluationContext) -> None:
+        """Initialize all providers in parallel."""
+        errors: list[Exception] = []
+        
+        for name, provider in self._registered_providers:
+            try:
+                provider.initialize(evaluation_context)
+            except Exception as e:
+                errors.append(Exception(f"Provider '{name}' initialization failed: {e}"))
+        
+        if errors:
+            # Aggregate errors
+            error_msgs = "; ".join(str(e) for e in errors)
+            raise GeneralError(f"Multi-provider initialization failed: {error_msgs}")
+
+    def shutdown(self) -> None:
+        """Shutdown all providers."""
+        for _, provider in self._registered_providers:
+            try:
+                provider.shutdown()
+            except Exception:
+                # Log but don't fail shutdown
+                pass
+
+    def _evaluate_with_providers(
+        self,
+        flag_key: str,
+        default_value: FlagValueType,
+        evaluation_context: EvaluationContext | None,
+        resolve_fn: Callable[[FeatureProvider, str, FlagValueType, EvaluationContext | None], FlagResolutionDetails],
+    ) -> FlagResolutionDetails[FlagValueType]:
+        """
+        Core evaluation logic that delegates to providers based on strategy.
+        
+        :param flag_key: The flag key to evaluate
+        :param default_value: Default value for the flag
+        :param evaluation_context: Evaluation context
+        :param resolve_fn: Function to call on each provider for resolution
+        :return: Final resolution details
+        """
+        results: list[tuple[str, FlagResolutionDetails]] = []
+        
+        for provider_name, provider in self._registered_providers:
+            try:
+                result = resolve_fn(provider, flag_key, default_value, evaluation_context)
+                results.append((provider_name, result))
+                
+                # In sequential mode, stop if strategy says to use this result
+                if (self.strategy.run_mode == "sequential" and 
+                    self.strategy.should_use_result(flag_key, provider_name, result)):
+                    return result
+                    
+            except Exception as e:
+                # Record error but continue to next provider
+                error_result = FlagResolutionDetails(
+                    flag_key=flag_key,
+                    value=default_value,
+                    reason=Reason.ERROR,
+                    error_message=str(e),
+                )
+                results.append((provider_name, error_result))
+        
+        # In parallel mode or if all sequential attempts completed, pick best result
+        for provider_name, result in results:
+            if self.strategy.should_use_result(flag_key, provider_name, result):
+                return result
+        
+        # No successful result - return last error or default
+        if results:
+            return results[-1][1]
+        
+        return FlagResolutionDetails(
+            flag_key=flag_key,
+            value=default_value,
+            reason=Reason.ERROR,
+            error_message="No providers returned a result",
+        )
+
+    def resolve_boolean_details(
+        self,
+        flag_key: str,
+        default_value: bool,
+        evaluation_context: EvaluationContext | None = None,
+    ) -> FlagResolutionDetails[bool]:
+        return self._evaluate_with_providers(
+            flag_key,
+            default_value,
+            evaluation_context,
+            lambda p, k, d, ctx: p.resolve_boolean_details(k, d, ctx),
+        )
+
+    async def resolve_boolean_details_async(
+        self,
+        flag_key: str,
+        default_value: bool,
+        evaluation_context: EvaluationContext | None = None,
+    ) -> FlagResolutionDetails[bool]:
+        # For async, delegate to sync for now (async aggregation would be more complex)
+        return self.resolve_boolean_details(flag_key, default_value, evaluation_context)
+
+    def resolve_string_details(
+        self,
+        flag_key: str,
+        default_value: str,
+        evaluation_context: EvaluationContext | None = None,
+    ) -> FlagResolutionDetails[str]:
+        return self._evaluate_with_providers(
+            flag_key,
+            default_value,
+            evaluation_context,
+            lambda p, k, d, ctx: p.resolve_string_details(k, d, ctx),
+        )
+
+    async def resolve_string_details_async(
+        self,
+        flag_key: str,
+        default_value: str,
+        evaluation_context: EvaluationContext | None = None,
+    ) -> FlagResolutionDetails[str]:
+        return self.resolve_string_details(flag_key, default_value, evaluation_context)
+
+    def resolve_integer_details(
+        self,
+        flag_key: str,
+        default_value: int,
+        evaluation_context: EvaluationContext | None = None,
+    ) -> FlagResolutionDetails[int]:
+        return self._evaluate_with_providers(
+            flag_key,
+            default_value,
+            evaluation_context,
+            lambda p, k, d, ctx: p.resolve_integer_details(k, d, ctx),
+        )
+
+    async def resolve_integer_details_async(
+        self,
+        flag_key: str,
+        default_value: int,
+        evaluation_context: EvaluationContext | None = None,
+    ) -> FlagResolutionDetails[int]:
+        return self.resolve_integer_details(flag_key, default_value, evaluation_context)
+
+    def resolve_float_details(
+        self,
+        flag_key: str,
+        default_value: float,
+        evaluation_context: EvaluationContext | None = None,
+    ) -> FlagResolutionDetails[float]:
+        return self._evaluate_with_providers(
+            flag_key,
+            default_value,
+            evaluation_context,
+            lambda p, k, d, ctx: p.resolve_float_details(k, d, ctx),
+        )
+
+    async def resolve_float_details_async(
+        self,
+        flag_key: str,
+        default_value: float,
+        evaluation_context: EvaluationContext | None = None,
+    ) -> FlagResolutionDetails[float]:
+        return self.resolve_float_details(flag_key, default_value, evaluation_context)
+
+    def resolve_object_details(
+        self,
+        flag_key: str,
+        default_value: Sequence[FlagValueType] | Mapping[str, FlagValueType],
+        evaluation_context: EvaluationContext | None = None,
+    ) -> FlagResolutionDetails[Sequence[FlagValueType] | Mapping[str, FlagValueType]]:
+        return self._evaluate_with_providers(
+            flag_key,
+            default_value,
+            evaluation_context,
+            lambda p, k, d, ctx: p.resolve_object_details(k, d, ctx),
+        )
+
+    async def resolve_object_details_async(
+        self,
+        flag_key: str,
+        default_value: Sequence[FlagValueType] | Mapping[str, FlagValueType],
+        evaluation_context: EvaluationContext | None = None,
+    ) -> FlagResolutionDetails[Sequence[FlagValueType] | Mapping[str, FlagValueType]]:
+        return self.resolve_object_details(flag_key, default_value, evaluation_context)

--- a/tests/test_multi_provider.py
+++ b/tests/test_multi_provider.py
@@ -1,0 +1,297 @@
+import pytest
+
+from openfeature import api
+from openfeature.evaluation_context import EvaluationContext
+from openfeature.exception import GeneralError
+from openfeature.flag_evaluation import FlagResolutionDetails, Reason
+from openfeature.provider import Metadata
+from openfeature.provider.in_memory_provider import InMemoryFlag, InMemoryProvider
+from openfeature.provider.multi_provider import (
+    FirstMatchStrategy,
+    MultiProvider,
+    ProviderEntry,
+)
+from openfeature.provider.no_op_provider import NoOpProvider
+
+
+def test_multi_provider_requires_at_least_one_provider():
+    # Given/When/Then
+    with pytest.raises(ValueError, match="At least one provider must be provided"):
+        MultiProvider([])
+
+
+def test_multi_provider_uses_explicit_names():
+    # Given
+    provider_a = NoOpProvider()
+    provider_b = NoOpProvider()
+    
+    # When
+    multi = MultiProvider([
+        ProviderEntry(provider_a, name="first"),
+        ProviderEntry(provider_b, name="second"),
+    ])
+    
+    # Then
+    assert len(multi._registered_providers) == 2
+    assert multi._registered_providers[0][0] == "first"
+    assert multi._registered_providers[1][0] == "second"
+
+
+def test_multi_provider_generates_unique_names_when_metadata_conflicts():
+    # Given
+    provider_a = NoOpProvider()
+    provider_b = NoOpProvider()
+    
+    # When - both have same metadata name "NoOpProvider"
+    multi = MultiProvider([
+        ProviderEntry(provider_a),
+        ProviderEntry(provider_b),
+    ])
+    
+    # Then - names are auto-indexed
+    assert len(multi._registered_providers) == 2
+    names = [name for name, _ in multi._registered_providers]
+    assert names == ["NoOpProvider_1", "NoOpProvider_2"]
+
+
+def test_multi_provider_rejects_duplicate_explicit_names():
+    # Given
+    provider_a = NoOpProvider()
+    provider_b = NoOpProvider()
+    
+    # When/Then
+    with pytest.raises(ValueError, match="Provider name 'duplicate' is not unique"):
+        MultiProvider([
+            ProviderEntry(provider_a, name="duplicate"),
+            ProviderEntry(provider_b, name="duplicate"),
+        ])
+
+
+def test_multi_provider_first_match_strategy_sequential():
+    # Given
+    flags_a = {
+        "flag1": InMemoryFlag("off", {"on": True, "off": False}),
+    }
+    flags_b = {
+        "flag1": InMemoryFlag("on", {"on": True, "off": False}),
+        "flag2": InMemoryFlag("on", {"on": True, "off": False}),
+    }
+    
+    provider_a = InMemoryProvider(flags_a)
+    provider_b = InMemoryProvider(flags_b)
+    
+    multi = MultiProvider([
+        ProviderEntry(provider_a, name="primary"),
+        ProviderEntry(provider_b, name="fallback"),
+    ], strategy=FirstMatchStrategy())
+    
+    # When - flag1 exists in both, should use first (primary)
+    result = multi.resolve_boolean_details("flag1", False)
+    
+    # Then
+    assert result.value == False  # primary provider returns "off" variant
+    assert result.reason != Reason.ERROR
+
+
+def test_multi_provider_fallback_to_second_provider():
+    # Given
+    flags_a = {}  # primary has no flags
+    flags_b = {
+        "flag1": InMemoryFlag("on", {"on": True, "off": False}),
+    }
+    
+    provider_a = InMemoryProvider(flags_a)
+    provider_b = InMemoryProvider(flags_b)
+    
+    multi = MultiProvider([
+        ProviderEntry(provider_a, name="primary"),
+        ProviderEntry(provider_b, name="fallback"),
+    ])
+    
+    # When - flag1 doesn't exist in primary, should fallback
+    result = multi.resolve_boolean_details("flag1", False)
+    
+    # Then
+    assert result.value == True  # fallback provider has the flag
+    assert result.reason != Reason.ERROR
+
+
+def test_multi_provider_all_types_work():
+    # Given
+    flags = {
+        "bool-flag": InMemoryFlag("on", {"on": True, "off": False}),
+        "string-flag": InMemoryFlag("greeting", {"greeting": "hello", "farewell": "goodbye"}),
+        "int-flag": InMemoryFlag("big", {"small": 10, "big": 100}),
+        "float-flag": InMemoryFlag("pi", {"pi": 3.14, "e": 2.71}),
+        "object-flag": InMemoryFlag("full", {
+            "full": {"name": "test", "value": 42},
+            "empty": {},
+        }),
+    }
+    
+    provider = InMemoryProvider(flags)
+    multi = MultiProvider([ProviderEntry(provider)])
+    
+    # When/Then
+    bool_result = multi.resolve_boolean_details("bool-flag", False)
+    assert bool_result.value == True
+    
+    string_result = multi.resolve_string_details("string-flag", "default")
+    assert string_result.value == "hello"
+    
+    int_result = multi.resolve_integer_details("int-flag", 0)
+    assert int_result.value == 100
+    
+    float_result = multi.resolve_float_details("float-flag", 0.0)
+    assert float_result.value == 3.14
+    
+    object_result = multi.resolve_object_details("object-flag", {})
+    assert object_result.value == {"name": "test", "value": 42}
+
+
+def test_multi_provider_initialize_all_providers():
+    # Given
+    provider_a = NoOpProvider()
+    provider_b = NoOpProvider()
+    
+    # Track if initialize was called
+    provider_a.initialize = lambda ctx: None
+    provider_b.initialize = lambda ctx: None
+    
+    a_initialized = False
+    b_initialized = False
+    
+    def track_a_init(ctx):
+        nonlocal a_initialized
+        a_initialized = True
+    
+    def track_b_init(ctx):
+        nonlocal b_initialized
+        b_initialized = True
+    
+    provider_a.initialize = track_a_init
+    provider_b.initialize = track_b_init
+    
+    multi = MultiProvider([
+        ProviderEntry(provider_a),
+        ProviderEntry(provider_b),
+    ])
+    
+    # When
+    multi.initialize(EvaluationContext())
+    
+    # Then
+    assert a_initialized
+    assert b_initialized
+
+
+def test_multi_provider_initialization_failures_are_aggregated():
+    # Given
+    provider_a = NoOpProvider()
+    provider_b = NoOpProvider()
+    
+    def fail_init(ctx):
+        raise Exception("Init failed")
+    
+    provider_a.initialize = fail_init
+    provider_b.initialize = fail_init
+    
+    multi = MultiProvider([
+        ProviderEntry(provider_a, name="a"),
+        ProviderEntry(provider_b, name="b"),
+    ])
+    
+    # When/Then
+    with pytest.raises(GeneralError, match="Multi-provider initialization failed"):
+        multi.initialize(EvaluationContext())
+
+
+def test_multi_provider_returns_error_when_no_providers_have_flag():
+    # Given
+    provider_a = InMemoryProvider({})
+    provider_b = InMemoryProvider({})
+    
+    multi = MultiProvider([
+        ProviderEntry(provider_a),
+        ProviderEntry(provider_b),
+    ])
+    
+    # When
+    result = multi.resolve_boolean_details("nonexistent", False)
+    
+    # Then
+    assert result.value == False  # default value
+    assert result.reason == Reason.ERROR
+
+
+@pytest.mark.asyncio
+async def test_multi_provider_async_methods_work():
+    # Given
+    flags = {
+        "async-flag": InMemoryFlag("on", {"on": True, "off": False}),
+    }
+    provider = InMemoryProvider(flags)
+    multi = MultiProvider([ProviderEntry(provider)])
+    
+    # When
+    result = await multi.resolve_boolean_details_async("async-flag", False)
+    
+    # Then
+    assert result.value == True
+    assert result.reason != Reason.ERROR
+
+
+def test_multi_provider_can_be_used_with_api():
+    # Given
+    api.clear_providers()
+    flags = {
+        "api-flag": InMemoryFlag("on", {"on": True, "off": False}),
+    }
+    provider = InMemoryProvider(flags)
+    multi = MultiProvider([ProviderEntry(provider)])
+    
+    # When
+    api.set_provider(multi)
+    client = api.get_client()
+    value = client.get_boolean_value("api-flag", False)
+    
+    # Then
+    assert value == True
+
+
+def test_multi_provider_metadata():
+    # Given
+    multi = MultiProvider([ProviderEntry(NoOpProvider())])
+    
+    # When
+    metadata = multi.get_metadata()
+    
+    # Then
+    assert metadata.name == "MultiProvider"
+
+
+def test_multi_provider_aggregates_hooks():
+    # Given
+    from unittest.mock import MagicMock
+    
+    provider_a = NoOpProvider()
+    provider_b = NoOpProvider()
+    
+    hook_a = MagicMock()
+    hook_b = MagicMock()
+    
+    provider_a.get_provider_hooks = lambda: [hook_a]
+    provider_b.get_provider_hooks = lambda: [hook_b]
+    
+    multi = MultiProvider([
+        ProviderEntry(provider_a),
+        ProviderEntry(provider_b),
+    ])
+    
+    # When
+    hooks = multi.get_provider_hooks()
+    
+    # Then
+    assert len(hooks) == 2
+    assert hook_a in hooks
+    assert hook_b in hooks


### PR DESCRIPTION
## Summary

Fixes #511

Implements the Multi-Provider as specified in the [OpenFeature Appendix A](https://openfeature.dev/specification/appendix-a/#multi-provider).

The Multi-Provider wraps multiple underlying providers in a unified interface, allowing a single client to interact with multiple flag sources simultaneously.

## Key Features

- **MultiProvider class** extending `AbstractProvider`
- **FirstMatchStrategy** - sequential evaluation, stops at first successful result
- **EvaluationStrategy protocol** - allows custom evaluation strategies
- **Provider name uniqueness** - explicit names, metadata-based, or auto-indexed (e.g., `Provider_1`, `Provider_2`)
- **Parallel initialization** - all providers initialized concurrently with error aggregation
- **Full flag type support** - boolean, string, integer, float, object
- **Hook aggregation** - combines hooks from all providers

## Use Cases

### Migration
Run old and new providers in parallel during migration:
```python
multi = MultiProvider([
    ProviderEntry(new_provider, name="primary"),
    ProviderEntry(old_provider, name="fallback")
])
```

### Multiple Data Sources
Combine environment variables, local files, and SaaS providers:
```python
multi = MultiProvider([
    ProviderEntry(env_var_provider),
    ProviderEntry(file_provider),
    ProviderEntry(saas_provider)
])
```

### Fallback Chain
Primary provider with cascading backups:
```python
multi = MultiProvider([
    ProviderEntry(primary),
    ProviderEntry(backup1),
    ProviderEntry(backup2)
])
```

## Example Usage

```python
from openfeature import api
from openfeature.provider import MultiProvider, ProviderEntry
from openfeature.provider.in_memory_provider import InMemoryProvider

# Define providers
provider_a = InMemoryProvider({"feature-a": ...})
provider_b = InMemoryProvider({"feature-b": ...})

# Create multi-provider
multi = MultiProvider([
    ProviderEntry(provider_a, name="primary"),
    ProviderEntry(provider_b, name="fallback")
])

# Set as the global provider
api.set_provider(multi)

# Use as normal
client = api.get_client()
value = client.get_boolean_value("feature-a", False)
```

## Implementation Details

### Provider Name Resolution
1. **Explicit name** - if `ProviderEntry(provider, name="custom")` is provided
2. **Metadata name** - if unique among all providers
3. **Indexed name** - `{metadata.name}_{index}` if duplicates exist (e.g., `NoOpProvider_1`, `NoOpProvider_2`)

Duplicate explicit names raise a `ValueError`.

### Evaluation Flow (FirstMatchStrategy)
1. Iterate through providers in order
2. Call the appropriate `resolve_*_details` method
3. If result has no error (`reason != ERROR`), use it immediately (sequential mode)
4. If error, continue to next provider
5. Return first successful result or last error

### Initialization
All providers are initialized in parallel. If any fail, errors are aggregated into a single `GeneralError` with details from all failures.

## Testing

Comprehensive test coverage includes:
- Provider name uniqueness and auto-indexing
- FirstMatchStrategy behavior (primary/fallback)
- All flag types (boolean, string, int, float, object)
- Parallel initialization
- Error aggregation
- Hook aggregation
- Integration with OpenFeature API

All tests pass ✅

## Future Enhancements (out of scope for this PR)

- **Status tracking** - aggregate provider statuses (READY, ERROR, FATAL, etc.)
- **Event re-emission** - forward provider events to SDK
- **Additional strategies** - parallel mode, custom aggregation logic
- **Async optimization** - truly parallel async evaluation

These can be added in follow-up PRs.

## References

- Spec: https://openfeature.dev/specification/appendix-a/#multi-provider
- JS implementation: https://github.com/open-feature/js-sdk-contrib/tree/main/libs/providers/multi-provider

Signed-off-by: vikasrao23 <vikasrao23@users.noreply.github.com>