### PR TITLE
feat: add set_provider_and_wait() for blocking initialization

### DIFF
--- a/openfeature/api.py
+++ b/openfeature/api.py
@@ -31,6 +31,7 @@ __all__ = [
     "remove_handler",
     "set_evaluation_context",
     "set_provider",
+    "set_provider_and_wait",
     "set_transaction_context",
     "set_transaction_context_propagator",
     "shutdown",
@@ -44,10 +45,34 @@ def get_client(
 
 
 def set_provider(provider: FeatureProvider, domain: str | None = None) -> None:
+    """Set the provider, calling initialize() synchronously.
+
+    Note: In a future major version, this function should run initialize()
+    in a background thread to match the non-blocking semantics of
+    set_provider() in the Java, Go, and Node.js SDKs. Callers who need
+    blocking behavior should migrate to set_provider_and_wait().
+    """
     if domain is None:
         provider_registry.set_default_provider(provider)
     else:
         provider_registry.set_provider(domain, provider)
+
+
+def set_provider_and_wait(provider: FeatureProvider, domain: str | None = None) -> None:
+    """Set the provider and wait for initialization to complete.
+
+    Blocks the calling thread until the provider's initialize() method
+    returns successfully or raises an exception. If initialization fails,
+    the exception is re-raised to the caller.
+
+    Spec reference: Requirement 1.1.2.4 - "The API SHOULD provide functions
+    to set a provider and wait for the initialize function to return or
+    abnormally terminate."
+    """
+    if domain is None:
+        provider_registry.set_default_provider_and_wait(provider)
+    else:
+        provider_registry.set_provider_and_wait(domain, provider)
 
 
 def clear_providers() -> None:


### PR DESCRIPTION
## Motivation

The Python SDK is the only major OpenFeature SDK missing `set_provider_and_wait()`. Java, Go, and Node.js all offer both blocking and non-blocking provider registration. The spec says it SHOULD exist (Requirement 1.1.2.4).

Without this, providers that block in `initialize()` (waiting for remote config, connecting to a service, etc.) have no way to signal that they're ready before the caller continues. The caller has no SDK-level mechanism to distinguish "provider is initialized and ready" from "set_provider returned but init might still be running."

This was surfaced by Datadog's Python OpenFeature provider ([FFL-1843](https://datadoghq.atlassian.net/browse/FFL-1843)), where `initialize()` needs to block until Remote Config delivers flag configuration.

## Changes

Purely additive -- no existing behavior is changed.

- **`set_provider_and_wait(provider, domain?)`**: Same as `set_provider()` but re-raises initialization exceptions to the caller. If `initialize()` succeeds, `PROVIDER_READY` is dispatched and the function returns. If `initialize()` raises, `PROVIDER_ERROR` is dispatched AND the exception propagates.
- **`set_provider()`**: Unchanged. Continues to call `initialize()` synchronously and swallow exceptions (dispatching `PROVIDER_ERROR` on failure).
- Added 3 new tests for `set_provider_and_wait`.

## Decisions

- **No behavior change to `set_provider()`**. Changing it to run async would be a breaking change for anyone doing `set_provider(p); client.evaluate(...)`. A note in the docstring suggests making it non-blocking in a future major version to match Java/Go/Node.js SDKs.
- **`_and_wait` re-raises exceptions** -- this is the only behavioral difference from `set_provider()`. It lets callers use try/except to handle initialization failures, matching `setProviderAndWait()` in Java (which throws `OpenFeatureError`).

## Spec Reference

> **Requirement 1.1.2.4**: The API SHOULD provide functions to set a provider and wait for the initialize function to return or abnormally terminate.