### PR TITLE
fix: reject boolean values for integer flags

### DIFF
--- a/openfeature/client.py
+++ b/openfeature/client.py
@@ -861,19 +861,6 @@ class OpenFeatureClient:
         default_value: FlagValueType,
         evaluation_context: EvaluationContext | None = None,
     ) -> FlagEvaluationDetails[FlagValueType]:
-        """
-        Resolve a flag asynchronously and validate the returned value.
-
-        Provider-reported errors are returned unchanged. A type mismatch detected
-        by the client returns the caller's default with TYPE_MISMATCH error details.
-
-        :param provider: the provider selected for this evaluation
-        :param flag_type: the requested flag type
-        :param flag_key: the key of the selected flag
-        :param default_value: fallback used for an unknown type or a type mismatch
-        :param evaluation_context: context passed to the provider
-        :return: evaluation details containing the resolved value or fallback
-        """
         get_details_callables_async: Mapping[FlagType, ResolveDetailsCallableAsync] = {
             FlagType.BOOLEAN: provider.resolve_boolean_details_async,
             FlagType.INTEGER: provider.resolve_integer_details_async,
@@ -1004,17 +991,6 @@ class OpenFeatureClient:
 def _typecheck_flag_value(
     value: typing.Any, flag_type: FlagType
 ) -> OpenFeatureError | None:
-    """
-    Check a resolved value against the requested flag type without coercing it.
-
-    Booleans are not integer flag values, even though bool subclasses int in
-    Python. Other subclasses of the expected type remain valid.
-
-    :param value: the value returned by the provider
-    :param flag_type: the requested flag type
-    :return: None for a matching value, TypeMismatchError for an incompatible
-        value, or GeneralError for an unknown flag type
-    """
     type_map: TypeMap = {
         FlagType.BOOLEAN: bool,
         FlagType.STRING: str,
@@ -1025,6 +1001,7 @@ def _typecheck_flag_value(
     py_type = type_map.get(flag_type)
     if not py_type:
         return GeneralError(error_message="Unknown flag type")
+    # bool subclasses int, but booleans are not integer flag values.
     if not isinstance(value, py_type) or (
         flag_type == FlagType.INTEGER and isinstance(value, bool)
     ):

--- a/openfeature/client.py
+++ b/openfeature/client.py
@@ -861,6 +861,19 @@ class OpenFeatureClient:
         default_value: FlagValueType,
         evaluation_context: EvaluationContext | None = None,
     ) -> FlagEvaluationDetails[FlagValueType]:
+        """
+        Resolve a flag asynchronously and validate the returned value.
+
+        Provider-reported errors are returned unchanged. A type mismatch detected
+        by the client returns the caller's default with TYPE_MISMATCH error details.
+
+        :param provider: the provider selected for this evaluation
+        :param flag_type: the requested flag type
+        :param flag_key: the key of the selected flag
+        :param default_value: fallback used for an unknown type or a type mismatch
+        :param evaluation_context: context passed to the provider
+        :return: evaluation details containing the resolved value or fallback
+        """
         get_details_callables_async: Mapping[FlagType, ResolveDetailsCallableAsync] = {
             FlagType.BOOLEAN: provider.resolve_boolean_details_async,
             FlagType.INTEGER: provider.resolve_integer_details_async,
@@ -991,6 +1004,17 @@ class OpenFeatureClient:
 def _typecheck_flag_value(
     value: typing.Any, flag_type: FlagType
 ) -> OpenFeatureError | None:
+    """
+    Check a resolved value against the requested flag type without coercing it.
+
+    Booleans are not integer flag values, even though bool subclasses int in
+    Python. Other subclasses of the expected type remain valid.
+
+    :param value: the value returned by the provider
+    :param flag_type: the requested flag type
+    :return: None for a matching value, TypeMismatchError for an incompatible
+        value, or GeneralError for an unknown flag type
+    """
     type_map: TypeMap = {
         FlagType.BOOLEAN: bool,
         FlagType.STRING: str,
@@ -1001,7 +1025,6 @@ def _typecheck_flag_value(
     py_type = type_map.get(flag_type)
     if not py_type:
         return GeneralError(error_message="Unknown flag type")
-    # bool is an int subclass in Python, but not an integer flag value.
     if not isinstance(value, py_type) or (
         flag_type == FlagType.INTEGER and isinstance(value, bool)
     ):

--- a/openfeature/client.py
+++ b/openfeature/client.py
@@ -890,7 +890,7 @@ class OpenFeatureClient:
         if err := _typecheck_flag_value(value=resolution.value, flag_type=flag_type):
             return FlagEvaluationDetails(
                 flag_key=flag_key,
-                value=resolution.value,
+                value=default_value,
                 reason=Reason.ERROR,
                 error_code=err.error_code,
                 error_message=err.error_message,
@@ -1001,6 +1001,9 @@ def _typecheck_flag_value(
     py_type = type_map.get(flag_type)
     if not py_type:
         return GeneralError(error_message="Unknown flag type")
-    if not isinstance(value, py_type):
+    # bool is an int subclass in Python, but not an integer flag value.
+    if not isinstance(value, py_type) or (
+        flag_type == FlagType.INTEGER and isinstance(value, bool)
+    ):
         return TypeMismatchError(f"Expected type {py_type} but got {type(value)}")
     return None

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -424,7 +424,6 @@ async def test_client_type_mismatch_exceptions():
 
 @pytest.mark.asyncio
 async def test_typecheck_flag_value_general_error():
-    """Unknown flag types produce GENERAL rather than TYPE_MISMATCH."""
     # Given
     flag_value = "A"
     flag_type = None
@@ -454,7 +453,6 @@ async def test_typecheck_flag_value_general_error():
 async def test_client_returns_default_on_type_mismatch(
     flag_type, flag_value, default_value, is_async
 ):
-    """Both APIs return typed defaults and pass the fallback to finally hooks."""
     provider = InMemoryProvider(
         {"flag": InMemoryFlag("enabled", {"enabled": flag_value})}
     )
@@ -520,7 +518,6 @@ async def test_client_returns_default_on_type_mismatch(
 async def test_client_preserves_matching_flag_types(
     flag_type, flag_value, default_value, is_async
 ):
-    """Matching values keep their type and successful evaluation details."""
     provider = InMemoryProvider(
         {"flag": InMemoryFlag("enabled", {"enabled": flag_value})}
     )
@@ -548,11 +545,7 @@ async def test_client_preserves_matching_flag_types(
 
 
 def test_typecheck_flag_value_accepts_integer_subclasses():
-    """Rejecting booleans must not reject other integer subclasses."""
-
     class IntegerValue(int):
-        """An integer subtype with the same value semantics as int."""
-
         pass
 
     assert _typecheck_flag_value(IntegerValue(1), FlagType.INTEGER) is None
@@ -560,7 +553,6 @@ def test_typecheck_flag_value_accepts_integer_subclasses():
 
 @pytest.mark.asyncio
 async def test_typecheck_flag_value_type_mismatch_error():
-    """An incompatible value reports both the expected and actual types."""
     # Given
     flag_value = "A"
     flag_type = FlagType.BOOLEAN

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -424,6 +424,7 @@ async def test_client_type_mismatch_exceptions():
 
 @pytest.mark.asyncio
 async def test_typecheck_flag_value_general_error():
+    """Unknown flag types produce GENERAL rather than TYPE_MISMATCH."""
     # Given
     flag_value = "A"
     flag_type = None
@@ -453,6 +454,7 @@ async def test_typecheck_flag_value_general_error():
 async def test_client_returns_default_on_type_mismatch(
     flag_type, flag_value, default_value, is_async
 ):
+    """Both APIs return typed defaults and pass the fallback to finally hooks."""
     provider = InMemoryProvider(
         {"flag": InMemoryFlag("enabled", {"enabled": flag_value})}
     )
@@ -518,6 +520,7 @@ async def test_client_returns_default_on_type_mismatch(
 async def test_client_preserves_matching_flag_types(
     flag_type, flag_value, default_value, is_async
 ):
+    """Matching values keep their type and successful evaluation details."""
     provider = InMemoryProvider(
         {"flag": InMemoryFlag("enabled", {"enabled": flag_value})}
     )
@@ -545,7 +548,11 @@ async def test_client_preserves_matching_flag_types(
 
 
 def test_typecheck_flag_value_accepts_integer_subclasses():
+    """Rejecting booleans must not reject other integer subclasses."""
+
     class IntegerValue(int):
+        """An integer subtype with the same value semantics as int."""
+
         pass
 
     assert _typecheck_flag_value(IntegerValue(1), FlagType.INTEGER) is None
@@ -553,6 +560,7 @@ def test_typecheck_flag_value_accepts_integer_subclasses():
 
 @pytest.mark.asyncio
 async def test_typecheck_flag_value_type_mismatch_error():
+    """An incompatible value reports both the expected and actual types."""
     # Given
     flag_value = "A"
     flag_type = FlagType.BOOLEAN

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -434,6 +434,123 @@ async def test_typecheck_flag_value_general_error():
     assert err.error_message == "Unknown flag type"
 
 
+@pytest.mark.parametrize(
+    "flag_type, flag_value, default_value",
+    [
+        ("integer", True, 1),
+        ("integer", False, 0),
+        ("float", True, 1.0),
+        ("float", False, 0.0),
+        ("boolean", 1, False),
+        ("integer", "1", 0),
+        ("float", 1, 0.0),
+        ("string", True, "fallback"),
+        ("object", True, {}),
+    ],
+)
+@pytest.mark.parametrize("is_async", [False, True], ids=["sync", "async"])
+@pytest.mark.asyncio
+async def test_client_returns_default_on_type_mismatch(
+    flag_type, flag_value, default_value, is_async
+):
+    provider = InMemoryProvider(
+        {"flag": InMemoryFlag("enabled", {"enabled": flag_value})}
+    )
+    api.set_provider_and_wait(provider)
+    client = get_client()
+    spy_hook = MagicMock(spec=Hook)
+    client.add_hooks([spy_hook])
+    suffix = "_async" if is_async else ""
+
+    get_details = getattr(client, f"get_{flag_type}_details{suffix}")
+    details = get_details("flag", default_value)
+    if is_async:
+        details = await details
+
+    assert details.flag_key == "flag"
+    assert details.value == default_value
+    # Equality alone cannot distinguish True from 1 (or False from 0).
+    assert type(details.value) is type(default_value)
+    assert details.reason == Reason.ERROR
+    assert details.error_code == ErrorCode.TYPE_MISMATCH
+    expected_type = (dict, list) if flag_type == "object" else type(default_value)
+    assert (
+        details.error_message
+        == f"Expected type {expected_type} but got {type(flag_value)}"
+    )
+    spy_hook.error.assert_called_once()
+    assert (
+        spy_hook.error.call_args.kwargs["exception"].error_code
+        == ErrorCode.TYPE_MISMATCH
+    )
+    spy_hook.after.assert_not_called()
+    spy_hook.finally_after.assert_called_once()
+    assert spy_hook.finally_after.call_args.kwargs["details"].value == default_value
+    assert type(spy_hook.finally_after.call_args.kwargs["details"].value) is type(
+        default_value
+    )
+
+    get_value = getattr(client, f"get_{flag_type}_value{suffix}")
+    value = get_value("flag", default_value)
+    if is_async:
+        value = await value
+    assert value == default_value
+    assert type(value) is type(default_value)
+
+
+@pytest.mark.parametrize(
+    "flag_type, flag_value, default_value",
+    [
+        ("boolean", True, False),
+        ("boolean", False, True),
+        ("integer", 0, -1),
+        ("integer", 1, -1),
+        ("integer", -1, 0),
+        ("float", 0.0, -1.0),
+        ("float", 1.5, -1.0),
+        ("string", "enabled", "default"),
+        ("object", {"enabled": True}, {}),
+        ("object", [True, 1, "enabled"], []),
+    ],
+)
+@pytest.mark.parametrize("is_async", [False, True], ids=["sync", "async"])
+@pytest.mark.asyncio
+async def test_client_preserves_matching_flag_types(
+    flag_type, flag_value, default_value, is_async
+):
+    provider = InMemoryProvider(
+        {"flag": InMemoryFlag("enabled", {"enabled": flag_value})}
+    )
+    api.set_provider_and_wait(provider)
+    client = get_client()
+    suffix = "_async" if is_async else ""
+
+    get_details = getattr(client, f"get_{flag_type}_details{suffix}")
+    details = get_details("flag", default_value)
+    if is_async:
+        details = await details
+
+    assert details.value == flag_value
+    assert type(details.value) is type(flag_value)
+    assert details.variant == "enabled"
+    assert details.reason == Reason.STATIC
+    assert details.error_code is None
+
+    get_value = getattr(client, f"get_{flag_type}_value{suffix}")
+    value = get_value("flag", default_value)
+    if is_async:
+        value = await value
+    assert value == flag_value
+    assert type(value) is type(flag_value)
+
+
+def test_typecheck_flag_value_accepts_integer_subclasses():
+    class IntegerValue(int):
+        pass
+
+    assert _typecheck_flag_value(IntegerValue(1), FlagType.INTEGER) is None
+
+
 @pytest.mark.asyncio
 async def test_typecheck_flag_value_type_mismatch_error():
     # Given


### PR DESCRIPTION
## This PR

I reproduced the behavior reported by @aepfli in #619: requesting a boolean flag through `get_integer_details` returns the boolean as a successful evaluation, instead of returning the integer default with `TYPE_MISMATCH`.

The caller gets neither the expected type nor an indication that the flag is misconfigured for that request. The fallback is silently bypassed because Python considers `bool` a subclass of `int`, so `isinstance(True, int)` passes the client's type check.

### Reproducing the problem

This example uses the built-in provider; no flag server or credentials are needed. Run it with `uv run --frozen python repro.py` after saving it as `repro.py` in the checkout:

```python
import asyncio

from openfeature import api
from openfeature.provider.in_memory_provider import InMemoryFlag, InMemoryProvider


async def main():
    api.set_provider_and_wait(
        InMemoryProvider({"flag": InMemoryFlag("on", {"on": True})})
    )
    try:
        client = api.get_client()
        for mode, details in (
            ("sync", client.get_integer_details("flag", 1)),
            ("async", await client.get_integer_details_async("flag", 1)),
        ):
            error = details.error_code.value if details.error_code else None
            print(
                f"{mode}: {details.value!r} ({type(details.value).__name__}), "
                f"{details.reason.value}, {error}"
            )
    finally:
        api.shutdown()


asyncio.run(main())
```

On the base commit, `371aca1`:

```text
sync: True (bool), STATIC, None
async: True (bool), STATIC, None
```

With this patch, the same example returns the supplied default and reports the mismatch:

```text
sync: 1 (int), ERROR, TYPE_MISMATCH
async: 1 (int), ERROR, TYPE_MISMATCH
```

I also checked `False` with a default of `0`. The type matters here: a test that only checks equality would pass even before the fix, since `True == 1` and `False == 0`.

### Why there are two changes

The shared type check now excludes booleans when the requested type is INTEGER. I kept `isinstance` for everything else so this doesn't also reject valid integer subclasses or change how other flag types are handled.

That change alone wasn't enough for the async API. While checking it, I found that the async type-mismatch branch still constructed its result with `resolution.value`. It reported an error, but returned the rejected value anyway. The second change uses `default_value` in that branch, matching the sync behavior.

This also corrects the async fallback for other client-detected type mismatches, which is why the tests cover more than bool-to-int. It doesn't change provider implementations or introduce type coercion. Boolean flags and objects containing booleans continue to work as before.

### Related Issues

Fixes #619. Thanks @aepfli for the reproduction and the conformance test that caught this.

### How to test

The added tests exercise both value and details getters through the real `InMemoryProvider`. They check the exact return type as well as the value, error details and hook behavior: a mismatch must run the error hook, skip the after hook, and give the finally hook the fallback value. There are also passing cases for valid flag values and an integer subclass, to check that the stricter bool handling doesn't affect them.

To run just these tests:

```sh
uv run --frozen pytest tests/test_client.py -q \
  -k 'client_returns_default_on_type_mismatch or client_preserves_matching_flag_types or typecheck_flag_value_accepts_integer_subclasses'
```

I ran the same 39 cases against the unmodified base and this patch. Before the fix, 11 failed and 28 passed: the failures were the two sync bool-to-int cases and the nine async mismatch cases. After the fix, all 39 passed.

The full suite passed on Python 3.10 through 3.14, with 211 tests on each version. The repository's Gherkin suite also passed on each version: 21 scenarios / 84 steps, using its pinned spec and in-memory provider. Ruff, mypy, the remaining pre-commit hooks, and the wheel/sdist build passed locally as well.

```sh
UV_FROZEN=1 uv run --frozen poe test-all
UV_FROZEN=1 uv run --frozen poe e2e
UV_FROZEN=1 uv run --frozen prek run --all-files --show-diff-on-failure
uv build --no-sources
```

### Notes

For a check independent of the tests added here, I ran the in-memory self-test from [python-sdk-contrib#409](https://github.com/open-feature/python-sdk-contrib/pull/409), at `d6de5dc`, against both SDK versions. The case marked as a known failure for #619 becomes `XPASS(strict)` with this patch. Running that unchanged test file with `--runxfail`, so the assertions run normally, gives 24 passed and 5 skipped. The skips are unsupported provider capabilities; the strict marker will need updating when that suite adopts the fixed SDK.

All results above are local macOS runs. I haven't tested against live flagd/OFREP servers, and these results don't replace hosted CI.
